### PR TITLE
inject the bundled eval CDN URL into the runframe during build

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@tscircuit/math-utils": "^0.0.18",
         "@tscircuit/miniflex": "^0.0.4",
         "@tscircuit/props": "^0.0.281",
-        "@tscircuit/runframe": "^0.0.712",
+        "@tscircuit/runframe": "^0.0.788",
         "@tscircuit/schematic-corpus": "^0.0.110",
         "@tscircuit/schematic-match-adapt": "^0.0.16",
         "@tscircuit/simple-3d-svg": "^0.0.38",
@@ -247,7 +247,7 @@
 
     "@tscircuit/props": ["@tscircuit/props@0.0.281", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-t4QUtm3LCzIh+R1rpPf4Gjb07mAdLPTW9uFL6kTHwl+A5oBhCy0hwpDxfGVy5Eo0cEOz9WdnKVoVMkbK5Pdcrw=="],
 
-    "@tscircuit/runframe": ["@tscircuit/runframe@0.0.712", "", {}, "sha512-4njpMqbiRDaCFOMrizgzcdfckugQzh19Ch+H3YjtJQt6BN6suKGcx+CcU2dy5UC54a0A7XsUmOV1aiy2yj+nZA=="],
+    "@tscircuit/runframe": ["@tscircuit/runframe@0.0.788", "", {}, "sha512-GWPnHy+8Xf0BtEDyd/uLFgahS9EiyO2IU9HjrwRj49lo0857GWQWZ6AhBiNAtNIaE8vtq+WWThH5gtxQOHYXKQ=="],
 
     "@tscircuit/schematic-autolayout": ["@tscircuit/schematic-autolayout@0.0.6", "", { "dependencies": { "@tscircuit/soup-util": "^0.0.38", "transformation-matrix": "^2.16.1" } }, "sha512-34cQxtlSylBKyHkzaMBCynaWJgN9c/mWm7cz63StTYIafKmfFs383K8Xoc4QX8HXCvVrHYl1aK15onZua9MxeA=="],
 
@@ -724,6 +724,8 @@
     "tscircuit/@tscircuit/footprinter": ["@tscircuit/footprinter@0.0.204", "", { "dependencies": { "@tscircuit/mm": "^0.0.8", "zod": "^3.23.8" }, "peerDependencies": { "circuit-json": "*" } }, "sha512-bKx6vFZDi3TG/NjCR1eRYcSumrz+b59eGaPA6vuZ2L76blsY3F0ytQj+/GcXe+UlvNT3SgPmaO+HJvuj/wGluw=="],
 
     "tscircuit/@tscircuit/props": ["@tscircuit/props@0.0.261", "", { "peerDependencies": { "circuit-json": "*", "react": "*", "zod": "*" } }, "sha512-Y5EpxyOuli+zeC24zIMfx79M7Ub907o9OEHSeW1Rvs5EgfGQJlEV9vYC/f7BEDrAb8YbeKN580bhFApFLHkoDQ=="],
+
+    "tscircuit/@tscircuit/runframe": ["@tscircuit/runframe@0.0.712", "", {}, "sha512-4njpMqbiRDaCFOMrizgzcdfckugQzh19Ch+H3YjtJQt6BN6suKGcx+CcU2dy5UC54a0A7XsUmOV1aiy2yj+nZA=="],
 
     "tscircuit/@tscircuit/schematic-corpus": ["@tscircuit/schematic-corpus@0.0.52", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-qCLWEa0eodRNhFQX++yX/4j5x3aZV52ssehVgcYRYe0JUGV11mqrQ+JN/EWhI9X3e7dpQmjqCzxhIYKuZOyXSw=="],
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@tscircuit/math-utils": "^0.0.18",
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/props": "^0.0.281",
-    "@tscircuit/runframe": "^0.0.712",
+    "@tscircuit/runframe": "^0.0.788",
     "@tscircuit/schematic-corpus": "^0.0.110",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/simple-3d-svg": "^0.0.38",

--- a/scripts/copy-runframe-standalone.ts
+++ b/scripts/copy-runframe-standalone.ts
@@ -7,9 +7,10 @@ const dest = join(destDir, 'browser.min.js');
 
 const content = await readFile(src, 'utf-8');
 
+const packageVersion = JSON.parse(await readFile(join(import.meta.dirname, '../package.json'), 'utf-8')).version;
 const modifiedContent = content.replace(
   '<--INJECT_TSCIRCUIT_EVAL_WEB_WORKER_BLOB_URL-->',
-  './dist/webworker.min.js'
+  `https://cdnjs.cloudflare.com/ajax/libs/tscircuit/${packageVersion}/webworker.min.js`
 );
 
 await mkdir(destDir, { recursive: true });

--- a/scripts/copy-runframe-standalone.ts
+++ b/scripts/copy-runframe-standalone.ts
@@ -1,9 +1,16 @@
-import { mkdir, copyFile } from 'fs/promises';
+import { mkdir, writeFile, readFile } from 'fs/promises';
 import { join } from 'node:path';
 
 const src = join(import.meta.dirname, '../node_modules/@tscircuit/runframe/dist/standalone.min.js');
 const destDir = join(import.meta.dirname, '../dist');
 const dest = join(destDir, 'browser.min.js');
 
+const content = await readFile(src, 'utf-8');
+
+const modifiedContent = content.replace(
+  '<--INJECT_TSCIRCUIT_EVAL_WEB_WORKER_BLOB_URL-->',
+  './dist/webworker.min.js'
+);
+
 await mkdir(destDir, { recursive: true });
-await copyFile(src, dest);
+await writeFile(dest, modifiedContent);


### PR DESCRIPTION
Tested it, this code works without making calls to eval cdn

```
<!DOCTYPE html>
<html lang="en">
  <head>
    <script>
        window.process = { env: { NODE_ENV: "production" } }
      </script>
    <script type="module" src="./dist/browser.min.js"></script>
    <script type="tscircuit-tsx">
      export default () => (
        <board>
          <resistor name="R1" resistance={1000} />
        </board>
      )
    </script>
  </head>
  <body>
  </body>
</html>
```