### PR TITLE
Allow specifying a ratsNestColor on net or a pin with pinAttributes fixes #796

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,8 @@
 export * from "@tscircuit/core"
 export * from "@tscircuit/eval"
-export type { ChipProps, PinLabelsProp } from "@tscircuit/props"
+export type { 
+  ChipProps, 
+  PinLabelsProp,
+  TraceProps,
+  SchematicLineProps
+} from "@tscircuit/props"


### PR DESCRIPTION
…o that the nets appear with that color via the rats nest in the pcb-viewer #796