### PR TITLE
Prevent bun release workflow from version commits

### DIFF
--- a/.github/workflows/bun-pver-release.yml
+++ b/.github/workflows/bun-pver-release.yml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   publish:
+    if: ${{ !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'v')) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- skip the bun-pver-release workflow when the triggering push commit message starts with `v`

## Testing
- bunx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_b_68e5cc2b94f0832eabd27d68fc331d67