### PR TITLE
Add @tscircuit/common to copy exclusion list

### DIFF
--- a/scripts/copy-core-versions.ts
+++ b/scripts/copy-core-versions.ts
@@ -6,6 +6,7 @@ const DO_NOT_SYNC_PACKAGE = [
   "@biomejs/biome",
   "@tscircuit/import-snippet",
   "@tscircuit/layout",
+  "@tscircuit/common",
   "@tscircuit/log-soup",
   "@tscircuit/schematic-autolayout",
   "@types/*",


### PR DESCRIPTION
## Summary
- add `@tscircuit/common` to the `DO_NOT_SYNC_PACKAGE` list so it isn't synced from core

## Testing
- `bunx tsc --noEmit` *(fails: tests reference ../dist which is not generated in repo)*
- `bun run format` *(fails: format script is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_68e6eb606924832ea232e2b67280ff18