### PR TITLE
chore: update calculate-packing version to ^0.0.68

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -34,7 +34,7 @@
         "@tscircuit/solver-utils": "^0.0.3",
         "bpc-graph": "^0.0.57",
         "calculate-elbow": "^0.0.12",
-        "calculate-packing": "0.0.66",
+        "calculate-packing": "^0.0.68",
         "circuit-json": "^0.0.325",
         "circuit-json-to-bpc": "^0.0.13",
         "circuit-json-to-connectivity-map": "^0.0.22",
@@ -374,7 +374,7 @@
 
     "calculate-elbow": ["calculate-elbow@0.0.12", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-UkGS4EhabJn1WR6+UyoWpcxhKMx6MxM7+rK+3G0JcaPLMiYlvv5pEuc91unC/nH7kLGHV9xsVavhr5jJ50o+HA=="],
 
-    "calculate-packing": ["calculate-packing@0.0.66", "", { "peerDependencies": { "@tscircuit/circuit-json-util": "*", "typescript": "^5" } }, "sha512-SerzVPGlkMTjKKi+zJ8K5jIjxi7rcNnV1VJ/TaD5A5/EKYrIu5Dfh6MjQMPuW9N4HQQ4ZgkvhAQX/DhAGjBM2w=="],
+    "calculate-packing": ["calculate-packing@0.0.68", "", { "peerDependencies": { "@tscircuit/circuit-json-util": "*", "typescript": "^5" } }, "sha512-FbTBKbvofrsf867iMGHIFbJiQ2B156pxHtO/7IifszXJ0tuzyaaQ9rj7iH7/G/yPwXM/B4mky5RDK7KWHoE4/Q=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
@@ -815,6 +815,8 @@
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tscircuit/circuit-json-flex/@tscircuit/miniflex": ["@tscircuit/miniflex@0.0.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-oRC0up2psp8dJD1CzXyUiFuhQZUWLdZNl9EAqOf/hHqXDhPKMU6wM79S+XQuaB0gdWNRnwcURHPPaKLw/ka3DQ=="],
+
+    "@tscircuit/core/calculate-packing": ["calculate-packing@0.0.66", "", { "peerDependencies": { "@tscircuit/circuit-json-util": "*", "typescript": "^5" } }, "sha512-SerzVPGlkMTjKKi+zJ8K5jIjxi7rcNnV1VJ/TaD5A5/EKYrIu5Dfh6MjQMPuW9N4HQQ4ZgkvhAQX/DhAGjBM2w=="],
 
     "bl/buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@tscircuit/solver-utils": "^0.0.3",
     "bpc-graph": "^0.0.57",
     "calculate-elbow": "^0.0.12",
-    "calculate-packing": "0.0.66",
+    "calculate-packing": "0.0.68",
     "circuit-json": "^0.0.325",
     "circuit-json-to-bpc": "^0.0.13",
     "circuit-json-to-connectivity-map": "^0.0.22",


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` file, upgrading the `calculate-packing` package from version 0.0.66 to 0.0.68. This ensures the project uses the latest features and bug fixes from that dependency.