### PR TITLE
feat: add polygon smtpad solder mask test and capacitive touch docs

### DIFF
--- a/docs/capacitive-touch-element.md
+++ b/docs/capacitive-touch-element.md
@@ -1,0 +1,242 @@
+# Capacitive Touch Element
+
+Capacitive touch sensors are a common PCB design pattern. They work by
+detecting changes in capacitance when a finger touches or approaches a copper
+pad. In tscircuit you can build capacitive touch pads and sliders using the
+`<smtpad>` element with the `coveredWithSolderMask` property.
+
+## How It Works
+
+A capacitive touch pad is simply a copper area on the PCB that is covered by
+solder mask. The solder mask acts as a dielectric layer, protecting the copper
+from direct contact while still allowing capacitive coupling with a finger.
+
+When `coveredWithSolderMask` is set on an `<smtpad>`, tscircuit generates the
+`is_covered_with_solder_mask` field in circuit-json, which tells downstream
+tools (gerber export, PCB viewers, 3D renderers) that the pad should remain
+covered by solder mask rather than being exposed for soldering.
+
+## Basic Touch Pad
+
+The simplest capacitive touch element is a single rectangular pad covered with
+solder mask:
+
+```tsx
+import { Circuit } from "tscircuit"
+
+const TouchPad = () => (
+  <board width="20mm" height="20mm">
+    <chip
+      name="TOUCH1"
+      footprint={
+        <footprint>
+          <smtpad
+            shape="rect"
+            width="10mm"
+            height="10mm"
+            portHints={["1"]}
+            coveredWithSolderMask
+          />
+        </footprint>
+      }
+    />
+  </board>
+)
+```
+
+This creates a 10mm x 10mm rectangular copper pad covered with solder mask.
+The pad is large enough for reliable finger detection.
+
+## Pad Shapes
+
+You can use any pad shape supported by `<smtpad>`. Each shape supports the
+`coveredWithSolderMask` property:
+
+### Rectangular Pad
+
+```tsx
+<smtpad
+  shape="rect"
+  width="10mm"
+  height="10mm"
+  portHints={["1"]}
+  coveredWithSolderMask
+/>
+```
+
+### Circular Pad
+
+```tsx
+<smtpad
+  shape="circle"
+  radius="5mm"
+  portHints={["1"]}
+  coveredWithSolderMask
+/>
+```
+
+### Pill-Shaped Pad
+
+```tsx
+<smtpad
+  shape="pill"
+  width="12mm"
+  height="6mm"
+  radius="3mm"
+  portHints={["1"]}
+  coveredWithSolderMask
+/>
+```
+
+### Polygon Pad
+
+Polygon pads allow arbitrary shapes for custom touch sensor geometry:
+
+```tsx
+<smtpad
+  shape="polygon"
+  points={[
+    { x: -5, y: -5 },
+    { x: 5, y: -5 },
+    { x: 5, y: 5 },
+    { x: -5, y: 5 },
+  ]}
+  portHints={["1"]}
+  coveredWithSolderMask
+/>
+```
+
+## Capacitive Touch Slider
+
+A touch slider is built by placing multiple touch pads in a row. The
+microcontroller reads each pad's capacitance to determine where along the
+slider the finger is positioned.
+
+```tsx
+import { Circuit } from "tscircuit"
+
+const TouchSlider = () => {
+  const padCount = 5
+  const padWidth = 4 // mm
+  const padHeight = 10 // mm
+  const padSpacing = 5 // mm
+  const totalWidth = padCount * padSpacing
+  const startX = -totalWidth / 2 + padSpacing / 2
+
+  return (
+    <board width="40mm" height="20mm">
+      {Array.from({ length: padCount }, (_, i) => (
+        <chip
+          key={`PAD${i + 1}`}
+          name={`PAD${i + 1}`}
+          pcbX={startX + i * padSpacing}
+          pcbY={0}
+          footprint={
+            <footprint>
+              <smtpad
+                shape="rect"
+                width={`${padWidth}mm`}
+                height={`${padHeight}mm`}
+                portHints={["1"]}
+                coveredWithSolderMask
+              />
+            </footprint>
+          }
+        />
+      ))}
+    </board>
+  )
+}
+```
+
+This creates five rectangular pads spaced evenly across the board. Each pad is
+covered with solder mask so a finger can slide across them without touching
+bare copper.
+
+## Connecting to a Microcontroller
+
+In a real design, each touch pad connects to a capacitive touch input on a
+microcontroller. Here is an example connecting a touch slider to an MCU:
+
+```tsx
+const TouchSliderWithMCU = () => {
+  const padCount = 5
+  const padSpacing = 5
+  const totalWidth = padCount * padSpacing
+  const startX = -totalWidth / 2 + padSpacing / 2
+
+  return (
+    <board width="50mm" height="30mm">
+      {Array.from({ length: padCount }, (_, i) => (
+        <chip
+          key={`PAD${i + 1}`}
+          name={`PAD${i + 1}`}
+          pcbX={startX + i * padSpacing}
+          pcbY={6}
+          footprint={
+            <footprint>
+              <smtpad
+                shape="rect"
+                width="4mm"
+                height="10mm"
+                portHints={["1"]}
+                coveredWithSolderMask
+              />
+            </footprint>
+          }
+        />
+      ))}
+
+      <chip name="U1" footprint="soic8" pcbY={-8} />
+
+      {Array.from({ length: padCount }, (_, i) => (
+        <trace
+          key={`trace${i + 1}`}
+          from={`.PAD${i + 1} > .1`}
+          to={`.U1 > .${i + 1}`}
+        />
+      ))}
+    </board>
+  )
+}
+```
+
+## Design Guidelines
+
+- **Pad size**: Use pads at least 8mm x 8mm for reliable finger detection.
+  Larger pads are more sensitive but take up more board space.
+
+- **Spacing**: Leave 0.5mm to 1mm gaps between adjacent slider pads.
+  Overlapping detection zones improve slider resolution.
+
+- **Ground plane**: Place a ground plane beneath the touch pads with a gap.
+  This creates a controlled reference capacitance.
+
+- **Trace routing**: Keep traces from touch pads to the MCU short and away
+  from noisy signals. Long or noisy traces degrade sensitivity.
+
+- **Solder mask thickness**: Standard solder mask (typically 10-25 um) works
+  well as the dielectric layer for capacitive sensing.
+
+## Circuit JSON Output
+
+When you use `coveredWithSolderMask` on an `<smtpad>`, the generated
+circuit-json includes `is_covered_with_solder_mask: true` on the `pcb_smtpad`
+element:
+
+```json
+{
+  "type": "pcb_smtpad",
+  "shape": "rect",
+  "width": 10,
+  "height": 10,
+  "x": 0,
+  "y": 0,
+  "layer": "top",
+  "is_covered_with_solder_mask": true,
+  "port_hints": ["1"]
+}
+```
+
+This field is recognized by PCB fabrication tools to keep the solder mask over
+the pad instead of creating an opening.

--- a/tests/capacitive-touch-slider.test.tsx
+++ b/tests/capacitive-touch-slider.test.tsx
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import React from "react"
+import { Circuit } from "../dist"
+
+test("capacitive touch slider with covered smtpads produces correct circuit json", async () => {
+  const circuit = new Circuit()
+
+  // A capacitive touch slider consists of multiple pads in a row, each
+  // covered with solder mask so that a finger can slide across them
+  // without directly contacting the copper.
+  const sliderPadCount = 5
+  const padWidth = 4 // mm
+  const padHeight = 10 // mm
+  const padSpacing = 5 // mm
+  const totalWidth = sliderPadCount * padSpacing
+  const startX = -totalWidth / 2 + padSpacing / 2
+
+  circuit.add(
+    <board width="40mm" height="20mm">
+      {Array.from({ length: sliderPadCount }, (_, i) => (
+        <chip
+          key={`PAD${i + 1}`}
+          name={`PAD${i + 1}`}
+          pcbX={startX + i * padSpacing}
+          pcbY={0}
+          footprint={
+            <footprint>
+              <smtpad
+                shape="rect"
+                width={`${padWidth}mm`}
+                height={`${padHeight}mm`}
+                portHints={["1"]}
+                coveredWithSolderMask
+              />
+            </footprint>
+          }
+        />
+      ))}
+    </board>,
+  )
+
+  circuit.render()
+
+  const circuitJson = circuit.getCircuitJson()
+
+  const smtpads = circuitJson.filter(
+    (el: any) => el.type === "pcb_smtpad",
+  ) as any[]
+
+  // Verify all slider pads are covered with solder mask
+  const coveredPads = smtpads.filter(
+    (p: any) => p.is_covered_with_solder_mask === true,
+  )
+  expect(coveredPads.length).toBe(sliderPadCount)
+
+  // Verify the pads have the correct dimensions
+  for (const pad of coveredPads) {
+    expect(pad.shape).toBe("rect")
+    expect(pad.width).toBeCloseTo(padWidth, 1)
+    expect(pad.height).toBeCloseTo(padHeight, 1)
+  }
+
+  // Verify pads are spaced correctly across the board
+  const xPositions = coveredPads
+    .map((p: any) => p.x)
+    .sort((a: number, b: number) => a - b)
+  for (let i = 1; i < xPositions.length; i++) {
+    const spacing = xPositions[i] - xPositions[i - 1]
+    expect(spacing).toBeCloseTo(padSpacing, 1)
+  }
+})

--- a/tests/polygon-smtpad-solder-mask.test.tsx
+++ b/tests/polygon-smtpad-solder-mask.test.tsx
@@ -1,0 +1,46 @@
+import { expect, test } from "bun:test"
+import React from "react"
+import { Circuit } from "../dist"
+
+test("polygon smtpad with coveredWithSolderMask sets is_covered_with_solder_mask in circuit json", async () => {
+  const circuit = new Circuit()
+
+  circuit.add(
+    <board width="20mm" height="20mm">
+      <chip
+        name="U1"
+        footprint={
+          <footprint>
+            <smtpad
+              shape="polygon"
+              points={[
+                { x: -3, y: -3 },
+                { x: 3, y: -3 },
+                { x: 3, y: 3 },
+                { x: -3, y: 3 },
+              ]}
+              portHints={["pin1"]}
+              coveredWithSolderMask
+            />
+          </footprint>
+        }
+      />
+    </board>,
+  )
+
+  circuit.render()
+
+  const circuitJson = circuit.getCircuitJson()
+
+  const smtpads = circuitJson.filter(
+    (el: any) => el.type === "pcb_smtpad",
+  ) as any[]
+
+  expect(smtpads.length).toBeGreaterThan(0)
+
+  const polygonPad = smtpads.find((p: any) => p.shape === "polygon")
+  expect(polygonPad).toBeTruthy()
+  expect(polygonPad.is_covered_with_solder_mask).toBe(true)
+  expect(polygonPad.points).toBeTruthy()
+  expect(polygonPad.points.length).toBe(4)
+})


### PR DESCRIPTION
## Summary
- Add test demonstrating polygon smtpads with `coveredWithSolderMask` property and verifying `is_covered_with_solder_mask` is set in circuit-json output
- Add test demonstrating a capacitive touch slider pattern with 5 evenly-spaced covered pads, verifying dimensions and spacing
- Add documentation for capacitive touch elements covering basic pads, all supported shapes, touch sliders, MCU connection, and design guidelines

/claim #786

## Test plan
- [x] `bun test` passes (4 tests, 27 assertions)
- [x] Polygon smtpad test verifies `is_covered_with_solder_mask` and point geometry
- [x] Capacitive touch slider test verifies pad count, dimensions, solder mask coverage, and spacing
- [x] Biome lint/format passes on new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)