### PR TITLE
Export CircuitJson and AnyCircuitElement from circuit-json

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,5 @@
 export * from "@tscircuit/core"
 export * from "@tscircuit/eval"
+export type { AnyCircuitElement, CircuitJson } from "circuit-json"
 export type { ChipProps, PinLabelsProp, CommonLayoutProps } from "@tscircuit/props"
 export { kicadFootprintStrings } from "@tscircuit/props"


### PR DESCRIPTION
### Motivation
- Make the `CircuitJson` and `AnyCircuitElement` types available from the package entrypoint so consumers can import these types from this module instead of importing directly from `circuit-json`.

### Description
- Added a type re-export in `index.ts`: `export type { AnyCircuitElement, CircuitJson } from "circuit-json"`.

### Testing
- Ran `bunx tsc --noEmit` (failed because tests import `../dist` before a build), ran `bun test tests/smoke1.test.tsx` (failed with `Cannot find module '../dist'`), and attempted `bun run format` (script not defined); no automated typecheck or test run passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b8691758e0832e998b7f96a858d400)