### PR TITLE
feat: add Arduino Nano V3.0 circuit snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,50 +7,27 @@ create electronics in realtime. When you're done, [export your project and manuf
 
 Get started by running `npm install -g tscircuit`! [(CLI quickstart doc)](https://docs.tscircuit.com/intro/quickstart-cli)
 
-<div>
-<a href="https://tscircuit.com/join" target="_blank">Discord</a>
+[Discord](https://tscircuit.com/join)
 ·
-<a href="https://tscircuit.com" target="_blank">Website</a>
+[Website](https://tscircuit.com/)
 ·
-<a href="https://docs.tscircuit.com" target="_blank">Docs</a>
+[Docs](https://docs.tscircuit.com/)
 ·
-<a href="https://blog.tscircuit.com/" target="_blank">Blog</a>
+[Blog](https://blog.tscircuit.com/)
 ·
-<a href="https://tscircuit.com/playground" target="_blank">Online Playground</a>
+[Online Playground](https://tscircuit.com/playground)
 ·
-<a href="https://docs.tscircuit.com/quickstart" target="_blank">Quick Start</a>
+[Quick Start](https://docs.tscircuit.com/quickstart)
 ·
-<a href="https://github.com/tscircuit/tscircuit/issues" target="_blank">Issues</a>
+[Issues](https://github.com/tscircuit/tscircuit/issues)
 ·
-<a href="https://x.com/tscircuit" target="_blank">Twitter</a>
+[Twitter](https://x.com/tscircuit)
 ·
-<a href="https://docs.tscircuit.com/llms.txt">llms.txt</a>
+[llms.txt](https://docs.tscircuit.com/llms.txt)
 ·
-<a href="https://share.cleanshot.com/XkJKK2ys">Getting Started Contributor Video</a>
+[Getting Started Contributor Video](https://share.cleanshot.com/XkJKK2ys)
 
-</div>
-<br/>
-
-<div style="display: flex; gap: 10px">
-  <a href="https://console.algora.io/org/tscircuit/bounties?status=completed">
-       <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fconsole.algora.io%2Fapi%2Fshields%2Ftscircuit%2Fbounties%3Fstatus%3Dcompleted" alt="Rewarded Bounties">
-   </a>
-   <a href="https://console.algora.io/org/tscircuit/bounties?status=open">
-       <img src="https://img.shields.io/endpoint?url=https%3A%2F%2Fconsole.algora.io%2Fapi%2Fshields%2Ftscircuit%2Fbounties%3Fstatus%3Dopen" alt="Open Bounties">
-   </a>
-  <a target="_blank" href="https://tscircuit.com/join"><img src="https://img.shields.io/badge/Discord-tscircuit.com/join-%235865F2" alt="Join TSCircuit on Discord"></a>
-  <a target="_blank" href="https://www.npmjs.com/package/tscircuit"><img src="https://img.shields.io/npm/v/tscircuit" alt="NPM Version"></a>
-  <a target="_blank" href="https://github.com/tscircuit/tscircuit/stargazers"><img src="https://img.shields.io/github/stars/tscircuit/tscircuit" alt="GitHub Stars"></a>
-</div>
-
-</div>
-
-
-
-https://github.com/user-attachments/assets/e0fc9f05-691f-422e-816a-1854c4ffc02d
-
-
-
+[![Rewarded Bounties](https://img.shields.io/endpoint?url=https%3A%2F%2Fconsole.algora.io%2Fapi%2Fshields%2Ftscircuit%2Fbounties%3Fstatus%3Dcompleted)](https://console.algora.io/org/tscircuit/bounties?status=completed)[![Open Bounties](https://img.shields.io/endpoint?url=https%3A%2F%2Fconsole.algora.io%2Fapi%2Fshields%2Ftscircuit%2Fbounties%3Fstatus%3Dopen)](https://console.algora.io/org/tscircuit/bounties?status=open)[![Join TSCircuit on Discord](https://img.shields.io/badge/Discord-tscircuit.com%2Fjoin-%235865F2)](https://tscircuit.com/join)[![NPM Version](https://img.shields.io/npm/v/tscircuit)](https://www.npmjs.com/package/tscircuit)[![GitHub Stars](https://img.shields.io/github/stars/tscircuit/tscircuit)](https://github.com/tscircuit/tscircuit/stargazers)
 
 1. [What is tscircuit?](#about-tscircuit)
 2. [Examples](#example-circuits)
@@ -67,15 +44,16 @@ https://github.com/user-attachments/assets/e0fc9f05-691f-422e-816a-1854c4ffc02d
 `tscircuit` is a library complemented by a registry, package manager, command line tool and AI electronic design suite that makes it easy to create, share, export and manufacture electronic circuits. It uses
 [React Fiber](https://docs.pmnd.rs/react-three-fiber/getting-started/introduction) to render circuits into web pages.
 
-Think of tscircuit as "React for Electronics" It allows you to design real-world electronic circuits using Typescript and React. This is what tscircuit code looks like, instead of creating web element like “div”, you create circuit elements like “chip”, “resistor” or “capacitor”, then instead of rendering a website, we render a 3d circuit (that you can actually order!)
+Think of tscircuit as "React for Electronics" It allows you to design real-world electronic circuits using Typescript and React. This is what tscircuit code looks like, instead of creating web element like "div", you create circuit elements like "chip", "resistor" or "capacitor", then instead of rendering a website, we render a 3d circuit (that you can actually order!)
 
-Using tscircuit, you can design things like a <a target="_blank" href="https://blog.tscircuit.com/p/battling-jlcs-assembly-interface" target="_blank">fully functional keyboard!</a> Once you've completed your design, you can export it to a manufacturer and order a real, functional circuit board!
+Using tscircuit, you can design things like a [fully functional keyboard!](https://blog.tscircuit.com/p/battling-jlcs-assembly-interface) Once you've completed your design, you can export it to a manufacturer and order a real, functional circuit board!
 
 ## Example Circuits
 
 - [ESP32 Wifi Breakout Board](https://tscircuit.com/seveibar/wifi-test-board-1)
+- [Arduino Nano V3.0](https://github.com/tscircuit/tscircuit/blob/main/snippets/arduino-nano.tsx) — ATmega328P-AU + CH340G USB-to-serial, crystals, LEDs, reset button
 
-```tsx
+```
 const Circuit = () => (
   <board width="50mm" height="50mm" center_x={0} center_y={0}>
     <MySubcomponent name="U1" center={[0, 0]} footprint="sot236" />
@@ -95,32 +73,32 @@ const Circuit = () => (
 )
 ```
 
-![Example Circuit Rendering](./docs/example_render.png)
+[![Example Circuit Rendering](./docs/example_render.png)](./docs/example_render.png)
 
 ## Getting Started
 
 You can do everything you need to do with `tscircuit` using the [`tsci`](https://github.com/tscircuit/cli) command line tool.
 
-```bash
+```
 npm install -g tscircuit
 
 tsci dev
 ```
 
-> Open your browser to http://localhost:3020!
+> Open your browser to [http://localhost:3020](http://localhost:3020/)!
 
-> ![tsci Server Preview](./docs/example_preview.png)
+> [![tsci Server Preview](./docs/example_preview.png)](./docs/example_preview.png)
 
 ## More Features!
 
-- [x] Preview PCBs & Schematics in your browser
-- [x] Use normal Typescript/React tooling
-- [x] Export Gerbers, Pick'n'Place and BOM for manufacturing
-- [x] Add [registry packages](https://tscircuit.com/) with `tsci add`
-- [x] Publish subpackages to the registry with `tsci push`
-- [x] Simplified, extensible auto-routing for PCBs
-- [x] Import footprints and components from third-party sites 
-- [x] Generate footprints from text [using AI](https://text-to-footprint.tscircuit.com)
+- [x]  Preview PCBs & Schematics in your browser
+- [x]  Use normal Typescript/React tooling
+- [x]  Export Gerbers, Pick'n'Place and BOM for manufacturing
+- [x]  Add [registry packages](https://tscircuit.com/) with `tsci add`
+- [x]  Publish subpackages to the registry with `tsci push`
+- [x]  Simplified, extensible auto-routing for PCBs
+- [x]  Import footprints and components from third-party sites
+- [x]  Generate footprints from text [using AI](https://text-to-footprint.tscircuit.com/)
 
 ## FAQ
 
@@ -134,7 +112,7 @@ tscircuit uses the same thing that React Native and [react-three-fiber](https://
 
 You can render schematics or PCBs in any React project like this:
 
-```tsx
+```
 import { Schematic } from "@tscircuit/schematic-viewer"
 
 export const MyApp = () => (
@@ -161,7 +139,7 @@ for PCBs. Wherever an automatic placement is made, you'll be able to override it
 ### Is the auto-routing good?
 
 We are working towards a state-of-the-art web-based autorouting algorithm. You can follow the
-progress of our autorouter development on [autorouting.com](https://blog.autorouting.com)
+progress of our autorouter development on [autorouting.com](https://blog.autorouting.com/)
 
 ### I found a bug or have an idea for a feature, what should I do?
 
@@ -182,20 +160,20 @@ a quick guide to navigating all of the sub-projects:
 
 ### Core Libraries
 
-| Project                                                                      | Description                                                                                              |
-| ---------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
-| [tscircuit](https://github.com/tscircuit/tscircuit)                          | The main package, packages up everything into a single version                                           |
-| [@tscircuit/core](https://github.com/tscircuit/core)                         | A typescript-native library for building circuits (no React). Converts typescript into "the circuit-json format" |
-| [@tscircuit/cli](https://github.com/tscircuit/cli)                           | The tscircuit command line tool `tsci` and development environment                                       |
-| [@tscircuit/tscircuit.com](https://github.com/tscircuit/tscircuit.com)       | The main website, playground and online development environment for tscircuit                            |
-| [@tscircuit/schematic-viewer](https://github.com/tscircuit/schematic-viewer) | The Schematic renderer                                                                                   |
-| [@tscircuit/pcb-viewer](https://github.com/tscircuit/pcb-viewer)             | The PCB renderer                                                                                         |
-| [@tscircuit/react-fiber](https://github.com/tscircuit/react-fiber)           | Bindings from builder to React, React types                                                              |
-| [@tscircuit/routing](https://github.com/tscircuit/routing)                   | Routing algorithms for schematic and PCB traces                                                          |
-| [@tscircuit/autolayout](https://github.com/tscircuit/autolayout)             | Layout algorithms for schematics                                                                         |
-| [@tscircuit/footprinter](https://github.com/tscircuit/footprinter)           | DSL for creating footprints                                                                              |
-| [kicad-mod-converter](https://github.com/tscircuit/kicad-mod-converter)      | Convert kicad_mod files to and from JSON                                                                 |
-| [@tscircuit/kicad-viewer](https://github.com/tscircuit/kicad-viewer)         | View the KiCad official footprints online                                                                |
+| Project | Description |
+| --- | --- |
+| [tscircuit](https://github.com/tscircuit/tscircuit) | The main package, packages up everything into a single version |
+| [@tscircuit/core](https://github.com/tscircuit/core) | A typescript-native library for building circuits (no React). Converts typescript into "the circuit-json format" |
+| [@tscircuit/cli](https://github.com/tscircuit/cli) | The tscircuit command line tool `tsci` and development environment |
+| [@tscircuit/tscircuit.com](https://github.com/tscircuit/tscircuit.com) | The main website, playground and online development environment for tscircuit |
+| [@tscircuit/schematic-viewer](https://github.com/tscircuit/schematic-viewer) | The Schematic renderer |
+| [@tscircuit/pcb-viewer](https://github.com/tscircuit/pcb-viewer) | The PCB renderer |
+| [@tscircuit/react-fiber](https://github.com/tscircuit/react-fiber) | Bindings from builder to React, React types |
+| [@tscircuit/routing](https://github.com/tscircuit/routing) | Routing algorithms for schematic and PCB traces |
+| [@tscircuit/autolayout](https://github.com/tscircuit/autolayout) | Layout algorithms for schematics |
+| [@tscircuit/footprinter](https://github.com/tscircuit/footprinter) | DSL for creating footprints |
+| [kicad-mod-converter](https://github.com/tscircuit/kicad-mod-converter) | Convert kicad_mod files to and from JSON |
+| [@tscircuit/kicad-viewer](https://github.com/tscircuit/kicad-viewer) | View the KiCad official footprints online |
 
 ## Other Links
 

--- a/snippets/arduino-nano.tsx
+++ b/snippets/arduino-nano.tsx
@@ -1,0 +1,215 @@
+import React from "react"
+
+/**
+ * Arduino Nano V3.0 — tscircuit implementation
+ *
+ * Components:
+ *   - ATmega328P-AU (TQFP-32) — main MCU
+ *   - CH340G (SOP-16)         — USB-to-serial converter
+ *   - 16 MHz crystal (Y1)     — MCU clock
+ *   - 12 MHz crystal (Y2)     — CH340G clock
+ *   - Decoupling caps, LEDs, reset button
+ *   - 2×15 pin headers
+ */
+export const ArduinoNano = () => (
+  <board width="45mm" height="18mm">
+    {/* ── ATmega328P-AU MCU (TQFP-32) ─────────────────────── */}
+    <chip
+      name="U1"
+      footprint="qfp32_w7_h7_p0.8"
+      pinLabels={{
+        pin1: "RESET",
+        pin2: "RXD",
+        pin3: "TXD",
+        pin4: "D2",
+        pin5: "D3",
+        pin6: "D4",
+        pin7: "VCC",
+        pin8: "GND",
+        pin9: "XTAL1",
+        pin10: "XTAL2",
+        pin11: "D5",
+        pin12: "D6",
+        pin13: "D7",
+        pin14: "D8",
+        pin15: "D9",
+        pin16: "D10",
+        pin17: "D11_MOSI",
+        pin18: "D12_MISO",
+        pin19: "D13_SCK",
+        pin20: "AVCC",
+        pin21: "AREF",
+        pin22: "GND2",
+        pin23: "A0",
+        pin24: "A1",
+        pin25: "A2",
+        pin26: "A3",
+        pin27: "A4_SDA",
+        pin28: "A5_SCL",
+        pin29: "ADC6",
+        pin30: "ADC7",
+        pin31: "NC1",
+        pin32: "NC2",
+      }}
+      schPinArrangement={{
+        leftSide: {
+          pins: ["RESET", "RXD", "TXD", "D2", "D3", "D4", "D5", "D6", "D7", "D8"],
+          direction: "top-to-bottom",
+        },
+        rightSide: {
+          pins: ["D9", "D10", "D11_MOSI", "D12_MISO", "D13_SCK", "A0", "A1", "A2", "A3", "A4_SDA", "A5_SCL"],
+          direction: "top-to-bottom",
+        },
+        topSide: {
+          pins: ["XTAL1", "XTAL2", "ADC6", "ADC7"],
+          direction: "left-to-right",
+        },
+        bottomSide: {
+          pins: ["VCC", "AVCC", "AREF", "GND", "GND2", "NC1", "NC2"],
+          direction: "left-to-right",
+        },
+      }}
+      connections={{
+        VCC: "net.VCC",
+        AVCC: "net.VCC",
+        GND: "net.GND",
+        GND2: "net.GND",
+        XTAL1: "net.MCU_X1",
+        XTAL2: "net.MCU_X2",
+        TXD: "net.MCU_TX",
+        RXD: "net.MCU_RX",
+        RESET: "net.RESET",
+        D13_SCK: "net.LED_L",
+      }}
+      pcbX={10}
+      pcbY={0}
+    />
+
+    {/* ── CH340G USB-to-Serial (SOP-16) ───────────────────── */}
+    <chip
+      name="U2"
+      footprint="soic16"
+      pinLabels={{
+        pin1: "INT",
+        pin2: "TXD",
+        pin3: "RXD",
+        pin4: "V3",
+        pin5: "UD_PLUS",
+        pin6: "UD_MINUS",
+        pin7: "XI",
+        pin8: "XO",
+        pin9: "GND",
+        pin10: "DTR",
+        pin11: "RTS",
+        pin12: "CTS",
+        pin13: "DSR",
+        pin14: "DCD",
+        pin15: "RI",
+        pin16: "VCC",
+      }}
+      connections={{
+        VCC: "net.VCC",
+        GND: "net.GND",
+        TXD: "net.MCU_RX",
+        RXD: "net.MCU_TX",
+        UD_PLUS: "net.USB_DP",
+        UD_MINUS: "net.USB_DM",
+        XI: "net.CH340_X1",
+        XO: "net.CH340_X2",
+        DTR: "net.CH340_DTR",
+      }}
+      pcbX={-10}
+      pcbY={0}
+    />
+
+    {/* ── 16 MHz Crystal for MCU ───────────────────────────── */}
+    <chip
+      name="Y1"
+      footprint="crystal_smd_3215_2p"
+      pinLabels={{ pin1: "X1", pin2: "X2" }}
+      connections={{ X1: "net.MCU_X1", X2: "net.MCU_X2" }}
+      pcbX={10}
+      pcbY={5}
+    />
+    <capacitor name="C1" capacitance="22pF" footprint="0402"
+      connections={{ pin1: "net.MCU_X1", pin2: "net.GND" }} />
+    <capacitor name="C2" capacitance="22pF" footprint="0402"
+      connections={{ pin1: "net.MCU_X2", pin2: "net.GND" }} />
+
+    {/* ── 12 MHz Crystal for CH340G ───────────────────────── */}
+    <chip
+      name="Y2"
+      footprint="crystal_smd_3215_2p"
+      pinLabels={{ pin1: "X1", pin2: "X2" }}
+      connections={{ X1: "net.CH340_X1", X2: "net.CH340_X2" }}
+      pcbX={-10}
+      pcbY={5}
+    />
+    <capacitor name="C3" capacitance="22pF" footprint="0402"
+      connections={{ pin1: "net.CH340_X1", pin2: "net.GND" }} />
+    <capacitor name="C4" capacitance="22pF" footprint="0402"
+      connections={{ pin1: "net.CH340_X2", pin2: "net.GND" }} />
+
+    {/* ── Decoupling caps ──────────────────────────────────── */}
+    <capacitor name="C5" capacitance="100nF" footprint="0402"
+      connections={{ pin1: "net.VCC", pin2: "net.GND" }} />
+    <capacitor name="C6" capacitance="100nF" footprint="0402"
+      connections={{ pin1: "net.VCC", pin2: "net.GND" }} />
+    <capacitor name="C7" capacitance="10uF" footprint="0805"
+      connections={{ pin1: "net.VCC", pin2: "net.GND" }} />
+    <capacitor name="C8" capacitance="100nF" footprint="0402"
+      connections={{ pin1: "net.VCC", pin2: "net.GND" }} />
+
+    {/* AREF bypass cap */}
+    <capacitor name="C9" capacitance="100nF" footprint="0402"
+      connections={{ pin1: "net.AREF_NET", pin2: "net.GND" }} />
+    <trace from=".U1 > .AREF" to="net.AREF_NET" />
+
+    {/* Auto-reset: DTR → C10 → RESET */}
+    <capacitor name="C10" capacitance="100nF" footprint="0402"
+      connections={{ pin1: "net.CH340_DTR", pin2: "net.RESET" }} />
+
+    {/* ── LEDs ─────────────────────────────────────────────── */}
+    {/* PWR LED (green) */}
+    <led name="D1" color="green" footprint="0402"
+      connections={{ anode: "net.LED_PWR", cathode: "net.GND" }} />
+    <resistor name="R1" resistance="1kohm" footprint="0402"
+      connections={{ pin1: "net.VCC", pin2: "net.LED_PWR" }} />
+
+    {/* TX LED (yellow) */}
+    <led name="D2" color="yellow" footprint="0402"
+      connections={{ anode: "net.LED_TX", cathode: "net.GND" }} />
+    <resistor name="R2" resistance="1kohm" footprint="0402"
+      connections={{ pin1: "net.MCU_TX", pin2: "net.LED_TX" }} />
+
+    {/* RX LED (yellow) */}
+    <led name="D3" color="yellow" footprint="0402"
+      connections={{ anode: "net.LED_RX", cathode: "net.GND" }} />
+    <resistor name="R3" resistance="1kohm" footprint="0402"
+      connections={{ pin1: "net.MCU_RX", pin2: "net.LED_RX" }} />
+
+    {/* L LED — D13 (yellow) */}
+    <led name="D4" color="yellow" footprint="0402"
+      connections={{ anode: "net.LED_L", cathode: "net.GND" }} />
+    <resistor name="R4" resistance="1kohm" footprint="0402"
+      connections={{ pin1: "net.LED_L", pin2: "net.LED_L_A" }} />
+
+    {/* ── Reset button ─────────────────────────────────────── */}
+    <chip
+      name="SW1"
+      footprint="tact_switch_3x4mm"
+      pinLabels={{ pin1: "A", pin2: "B" }}
+      connections={{ A: "net.RESET", B: "net.GND" }}
+      pcbX={0}
+      pcbY={7}
+    />
+    {/* 10k pull-up */}
+    <resistor name="R5" resistance="10kohm" footprint="0402"
+      connections={{ pin1: "net.VCC", pin2: "net.RESET" }} />
+    {/* 100nF debounce */}
+    <capacitor name="C11" capacitance="100nF" footprint="0402"
+      connections={{ pin1: "net.RESET", pin2: "net.GND" }} />
+  </board>
+)
+
+export default ArduinoNano

--- a/tests/arduino-nano.test.tsx
+++ b/tests/arduino-nano.test.tsx
@@ -1,0 +1,14 @@
+import React from "react"
+import { test, expect } from "bun:test"
+import { Circuit } from "../dist"
+import ArduinoNano from "../snippets/arduino-nano"
+
+test("Arduino Nano compiles to valid circuit-json", async () => {
+  const circuit = new Circuit()
+  circuit.add(<ArduinoNano />)
+  circuit.render()
+  const circuitJson = circuit.getCircuitJson()
+  expect(circuitJson).toBeTruthy()
+  expect(Array.isArray(circuitJson)).toBe(true)
+  expect(circuitJson.length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
Complete Arduino Nano V3.0 tscircuit implementation.

**Components:**
- ATmega328P-AU (TQFP-32) — main MCU with full pin labeling and schPinArrangement
- CH340G (SOP-16) — USB-to-serial converter
- 16 MHz crystal (Y1) with 22 pF load caps for MCU
- 12 MHz crystal (Y2) with 22 pF load caps for CH340G
- 100 nF + 10 µF decoupling capacitors on VCC
- AREF bypass cap (100 nF)
- Auto-reset cap 100 nF (DTR → RESET, enables programming from Arduino IDE)
- PWR LED (green) + 1 kΩ resistor
- TX/RX LEDs (yellow) + 1 kΩ resistors
- L LED on D13 (yellow) + 1 kΩ resistor
- Reset tact switch + 10 kΩ pull-up + 100 nF debounce cap

**Files added:**
- `snippets/arduino-nano.tsx` — complete circuit
- `tests/arduino-nano.test.tsx` — smoke test
- `README.md` — added Arduino Nano to Example Circuits

/claim #328