### PR TITLE
Add Arduino Nano to Example Circuits

### DIFF
--- a/.github/test-1223190249.txt
+++ b/.github/test-1223190249.txt
@@ -1,0 +1,1 @@
+test file

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Using tscircuit, you can design things like a <a target="_blank" href="https://b
 ## Example Circuits
 
 - [ESP32 Wifi Breakout Board](https://tscircuit.com/seveibar/wifi-test-board-1)
+- [Arduino Nano](https://tscircuit.com/Wong789/arduino-nano)
 
 ```tsx
 const Circuit = () => (


### PR DESCRIPTION
## Summary
Added Arduino Nano to the Example Circuits section in README.md, linking to the Arduino Nano tscircuit snippet.

## Changes
- Added `- [Arduino Nano](https://tscircuit.com/Wong789/arduino-nano)` to Example Circuits section

## Notes
This is part of the $100 bounty: https://algora.io/bounty/cm3krjn4k000ajy039e5fzirl

The Arduino Nano snippet is available at: https://tscircuit.com/Wong789/arduino-nano