### PR TITLE
fix: highlight same-net traces on hover in schematic viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@tscircuit/miniflex": "^0.0.4",
     "@tscircuit/ngspice-spice-engine": "^0.0.8",
     "@tscircuit/props": "^0.0.531",
-    "@tscircuit/runframe": "^0.0.1945",
+    "@tscircuit/runframe": "^0.0.1946",
     "@tscircuit/schematic-match-adapt": "^0.0.16",
     "@tscircuit/schematic-trace-solver": "^0.0.55",
     "@tscircuit/simple-3d-svg": "^0.0.41",


### PR DESCRIPTION
Fixes #1130 — traces on the same net should highlight together when any one is hovered.

## What changed

The actual fix is in the schematic-viewer package:
**tscircuit/schematic-viewer#196**

Added a `useEffect` in `SchematicViewer.tsx` that:
1. Attaches `mouseenter`/`mouseleave` handlers to trace base group SVG elements
2. On hover, reads `data-subcircuit-connectivity-map-key` (the net identifier present in all trace SVG elements)
3. Sets `data-net-hovered="true"` on all same-net trace elements
4. CSS reveals the existing invisible 8×-stroke hover outline for all highlighted traces
5. Cleans up attributes on `mouseleave`

This PR bumps `@tscircuit/runframe` to pick up the fix once the schematic-viewer change propagates through the dependency chain.

## Test

Verify at https://tscircuit.com/MrPicklePinosaur/tscircuit_demo#schematic — hover any trace, all connected same-net traces should highlight together.

/claim #1130