### PR TITLE
feat: add Arduino Nano V3.0 snippet (ATmega328P + CH340G)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Using tscircuit, you can design things like a <a target="_blank" href="https://b
 ## Example Circuits
 
 - [ESP32 Wifi Breakout Board](https://tscircuit.com/seveibar/wifi-test-board-1)
+-  [Arduino Nano V3.0](./snippets/arduino-nano.tsx)
 
 ```tsx
 const Circuit = () => (

--- a/snippets/arduino-nano.tsx
+++ b/snippets/arduino-nano.tsx
@@ -1,71 +1,79 @@
-import { sel } from "tscircuit"
-
-/**
- * Arduino Nano V3.0 (ATmega328P)
- *
- * Based on the official Arduino Nano schematic.
- * - MCU: ATmega328P (TQFP-32)
- * - USB-Serial: CH340G
- * - Regulator: AMS1117-5.0 (5V) + AMS1117-3.3 (3.3V)
- * - Clock: 16 MHz crystal
- * - Auto-reset via DTR -> 100nF -> RESET
- *
- * For tscircuit/tscircuit issue #328
- * https://github.com/tscircuit/tscircuit/issues/328
- */
+import React from "react"
 
 const ATmega328P = (props: any) => (
   <chip
     manufacturerPartNumber="ATmega328P-AU"
+    footprint="tqfp32_p0.8mm"
     pinLabels={{
-      pin1: "PD3",
-      pin2: "PD4",
-      pin3: "GND",
-      pin4: "VCC",
+      pin1: "D3",
+      pin2: "D4",
+      pin3: "GND1",
+      pin4: "VCC1",
       pin5: "GND2",
       pin6: "VCC2",
       pin7: "XTAL1",
       pin8: "XTAL2",
-      pin9: "PD5",
-      pin10: "PD6",
-      pin11: "PD7",
-      pin12: "PB0",
-      pin13: "PB1",
-      pin14: "PB2",
-      pin15: "PB3",
-      pin16: "PB4",
-      pin17: "PB5",
+      pin9: "D5",
+      pin10: "D6",
+      pin11: "D7",
+      pin12: "D8",
+      pin13: "D9",
+      pin14: "D10_SS",
+      pin15: "D11_MOSI",
+      pin16: "D12_MISO",
+      pin17: "D13_SCK",
       pin18: "AVCC",
-      pin19: "ADC6",
+      pin19: "A6",
       pin20: "AREF",
       pin21: "GND3",
-      pin22: "ADC7",
-      pin23: "PC0",
-      pin24: "PC1",
-      pin25: "PC2",
-      pin26: "PC3",
-      pin27: "PC4",
-      pin28: "PC5",
-      pin29: "PC6",
-      pin30: "PD0",
-      pin31: "PD1",
-      pin32: "PD2",
+      pin22: "A7",
+      pin23: "A0",
+      pin24: "A1",
+      pin25: "A2",
+      pin26: "A3",
+      pin27: "A4_SDA",
+      pin28: "A5_SCL",
+      pin29: "RESET",
+      pin30: "D0_RX",
+      pin31: "D1_TX",
+      pin32: "D2",
     }}
     schPinArrangement={{
       leftSide: {
         direction: "top-to-bottom",
         pins: [
-          "pin30", "pin31", "pin32", "pin1", "pin2",
-          "pin9", "pin10", "pin11", "pin12", "pin13",
-          "pin14", "pin15", "pin16", "pin17", "pin29",
+          "pin30",
+          "pin31",
+          "pin32",
+          "pin1",
+          "pin2",
+          "pin9",
+          "pin10",
+          "pin11",
+          "pin12",
+          "pin13",
+          "pin14",
+          "pin15",
+          "pin16",
+          "pin17",
+          "pin29",
         ],
       },
       rightSide: {
         direction: "top-to-bottom",
         pins: [
-          "pin23", "pin24", "pin25", "pin26", "pin27", "pin28",
-          "pin19", "pin22", "pin20", "pin18",
-          "pin7", "pin8",
+          "pin23",
+          "pin24",
+          "pin25",
+          "pin26",
+          "pin27",
+          "pin28",
+          "pin19",
+          "pin22",
+          "pin20",
+          "pin18",
+          "pin7",
+          "pin8",
         ],
       },
       topSide: {
@@ -84,6 +92,7 @@ const ATmega328P = (props: any) => (
 const CH340G = (props: any) => (
   <chip
     manufacturerPartNumber="CH340G"
+    footprint="soic16_w3.9mm_p1.27mm"
     pinLabels={{
       pin1: "TXD",
       pin2: "RXD",
@@ -105,7 +114,7 @@ const CH340G = (props: any) => (
     schPinArrangement={{
       leftSide: {
         direction: "top-to-bottom",
-        pins: ["pin16", "pin6", "pin7", "pin3", "pin4", "pin5", "pin8", "pin9"],
+        pins: ["pin16", "pin3", "pin6", "pin7", "pin4", "pin5", "pin8", "pin9"],
       },
       rightSide: {
         direction: "top-to-bottom",
@@ -116,262 +125,567 @@ const CH340G = (props: any) => (
   />
 )
 
-const AMS1117_5V = (props: any) => (
+const AMS1117 = (props: any) => (
   <chip
-    manufacturerPartNumber="AMS1117-5.0"
+    footprint="sot223"
     pinLabels={{
-      pin1: "ADJ_GND",
+      pin1: "GND",
       pin2: "OUT",
       pin3: "IN",
-      pin4: "OUT2",
-    }}
-    {...props}
-  />
-)
-
-const AMS1117_3V3 = (props: any) => (
-  <chip
-    manufacturerPartNumber="AMS1117-3.3"
-    pinLabels={{
-      pin1: "ADJ_GND",
-      pin2: "OUT",
-      pin3: "IN",
-      pin4: "OUT2",
+      pin4: "OUT_TAB",
     }}
     {...props}
   />
 )
 
 export const ArduinoNano = () => (
-  <board width="18mm" height="46mm" autorouter="auto-cloud">
+  <board width="45mm" height="18mm" autorouterEffortLevel="100x">
+    {/* GND copper pours on both layers */}
+    <copperpour
+      name="GND_TOP"
+      layer="top"
+      connectsTo="net.GND"
+      padMargin="0.25mm"
+      traceMargin="0.25mm"
+      boardEdgeMargin="0.4mm"
+    />
+    <copperpour
+      name="GND_BOTTOM"
+      layer="bottom"
+      connectsTo="net.GND"
+      padMargin="0.25mm"
+      traceMargin="0.25mm"
+      boardEdgeMargin="0.4mm"
+    />
 
-    {/* MCU */}
+    {/* MCU: ATmega328P-AU */}
     <ATmega328P
       name="U1"
-      footprint="tqfp32_p0.8mm"
-      schX={0} schY={0}
-      pcbX={0} pcbY={0}
+      schX={0}
+      schY={0}
+      pcbX={0}
+      pcbY={0}
       connections={{
-        pin30: sel.U2.pin2,
-        pin31: sel.U2.pin1,
-        pin4: "net.VCC5",
-        pin6: "net.VCC5",
-        pin18: "net.VCC5",
+        pin1: "net.D3",
+        pin2: "net.D4",
         pin3: "net.GND",
+        pin4: "net.VCC5",
         pin5: "net.GND",
+        pin6: "net.VCC5",
+        pin7: "net.XTAL16_1",
+        pin8: "net.XTAL16_2",
+        pin9: "net.D5",
+        pin10: "net.D6",
+        pin11: "net.D7",
+        pin12: "net.D8",
+        pin13: "net.D9",
+        pin14: "net.D10_SS",
+        pin15: "net.D11_MOSI",
+        pin16: "net.D12_MISO",
+        pin17: "net.D13_SCK",
+        pin18: "net.VCC5",
+        pin19: "net.A6",
+        pin20: "net.AREF",
         pin21: "net.GND",
-        pin7: sel.Y1.pin1,
-        pin8: sel.Y1.pin2,
+        pin22: "net.A7",
+        pin23: "net.A0",
+        pin24: "net.A1",
+        pin25: "net.A2",
+        pin26: "net.A3",
+        pin27: "net.A4_SDA",
+        pin28: "net.A5_SCL",
         pin29: "net.RESET",
-        pin15: sel.ICSP.pin4,
-        pin16: sel.ICSP.pin1,
-        pin17: sel.ICSP.pin3,
+        pin30: "net.D0_RX",
+        pin31: "net.D1_TX",
+        pin32: "net.D2",
       }}
     />
 
-    {/* USB-Serial bridge */}
+    {/* USB-Serial Bridge: CH340G */}
     <CH340G
       name="U2"
-      footprint="soic16_p1.27mm"
-      schX={16} schY={0}
-      pcbX={7} pcbY={0}
+      schX={12}
+      schY={0}
+      pcbX={11}
+      pcbY={1.5}
       connections={{
+        pin1: "net.D0_RX",
+        pin2: "net.D1_TX",
         pin3: "net.VCC3V3",
+        pin4: "net.USB_D_PLUS",
+        pin5: "net.USB_D_MINUS",
+        pin6: "net.XTAL12_1",
+        pin7: "net.XTAL12_2",
         pin8: "net.GND",
         pin9: "net.GND",
-        pin14: "net.DTR_CAP",
+        pin10: "net.GND",
+        pin11: "net.GND",
+        pin12: "net.GND",
+        pin13: "net.GND",
+        pin14: "net.DTR",
+        pin15: "net.GND",
         pin16: "net.VCC5",
       }}
     />
 
-    {/* 16 MHz Crystal */}
-    <chip
-      name="Y1"
-      manufacturerPartNumber="16MHz_Crystal"
-      footprint="crystal_hc49s_p4.88mm"
-      pinLabels={{ pin1: "IN", pin2: "OUT" }}
-      schX={-8} schY={4}
-      pcbX={-4} pcbY={4}
-    />
-    <capacitor name="C1" capacitance="22pF" footprint="0402"
-      schX={-12} schY={6} pcbX={-4} pcbY={5.5}
-      connections={{ pin1: sel.Y1.pin1, pin2: "net.GND" }} />
-    <capacitor name="C2" capacitance="22pF" footprint="0402"
-      schX={-12} schY={8} pcbX={-4} pcbY={6.5}
-      connections={{ pin1: sel.Y1.pin2, pin2: "net.GND" }} />
-
-    {/* 5V LDO */}
-    <AMS1117_5V
+    {/* 5V Regulator */}
+    <AMS1117
       name="U3"
-      footprint="sot223"
-      schX={16} schY={-10}
-      pcbX={7} pcbY={-8}
-      connections={{ pin1: "net.GND", pin2: "net.VCC5", pin3: "net.VIN", pin4: "net.VCC5" }}
+      manufacturerPartNumber="AMS1117-5.0"
+      schX={13}
+      schY={-7}
+      pcbX={12}
+      pcbY={-5.5}
+      connections={{
+        pin1: "net.GND",
+        pin2: "net.VCC5",
+        pin3: "net.VIN",
+        pin4: "net.VCC5",
+      }}
     />
-    <capacitor name="C7" capacitance="10uF" footprint="0805"
-      schX={20} schY={-10} pcbX={9} pcbY={-8}
-      connections={{ pin1: "net.VIN", pin2: "net.GND" }} />
-    <capacitor name="C8" capacitance="10uF" footprint="0805"
-      schX={20} schY={-12} pcbX={9} pcbY={-6}
-      connections={{ pin1: "net.VCC5", pin2: "net.GND" }} />
 
-    {/* 3.3V LDO */}
-    <AMS1117_3V3
+    {/* 3.3V Regulator */}
+    <AMS1117
       name="U4"
-      footprint="sot223"
-      schX={16} schY={-16}
-      pcbX={7} pcbY={-12}
-      connections={{ pin1: "net.GND", pin2: "net.VCC3V3", pin3: "net.VCC5", pin4: "net.VCC3V3" }}
+      manufacturerPartNumber="AMS1117-3.3"
+      schX={13}
+      schY={-11}
+      pcbX={17}
+      pcbY={-5.5}
+      connections={{
+        pin1: "net.GND",
+        pin2: "net.VCC3V3",
+        pin3: "net.VCC5",
+        pin4: "net.VCC3V3",
+      }}
     />
-    <capacitor name="C9" capacitance="10uF" footprint="0805"
-      schX={20} schY={-16} pcbX={9} pcbY={-12}
-      connections={{ pin1: "net.VCC3V3", pin2: "net.GND" }} />
 
-    {/* USB Mini-B */}
+    {/* Mini-USB B Connector */}
     <chip
-      name="J1"
-      manufacturerPartNumber="USB_MINI_B"
-      footprint="usb_mini_b_p2.0mm"
-      pinLabels={{ pin1: "VBUS", pin2: "D_MINUS", pin3: "D_PLUS", pin4: "ID", pin5: "GND" }}
-      schX={24} schY={4}
-      pcbX={9} pcbY={18}
-      connections={{ pin1: "net.VUSB", pin2: sel.U2.pin5, pin3: sel.U2.pin4, pin5: "net.GND" }}
+      name="J_USB"
+      manufacturerPartNumber="USB-MINI-B"
+      footprint="pinrow5_p1mm_id0.7mm_od1mm"
+      pinLabels={{
+        pin1: "VBUS",
+        pin2: "D_MINUS",
+        pin3: "D_PLUS",
+        pin4: "ID",
+        pin5: "GND",
+      }}
+      schX={22}
+      schY={0}
+      pcbX={21}
+      pcbY={0}
+      connections={{
+        pin1: "net.VUSB",
+        pin2: "net.USB_D_MINUS",
+        pin3: "net.USB_D_PLUS",
+        pin5: "net.GND",
+      }}
     />
-    <capacitor name="C10" capacitance="100nF" footprint="0402"
-      schX={24} schY={2}
-      connections={{ pin1: "net.VUSB", pin2: "net.GND" }} />
+
+    {/* USB Schottky diode */}
     <chip
-      name="D5"
-      manufacturerPartNumber="B5819W"
+      name="D_USB"
+      manufacturerPartNumber="SS14"
       footprint="sod123"
       pinLabels={{ pin1: "A", pin2: "K" }}
-      schX={22} schY={-2}
-      connections={{ pin1: "net.VUSB", pin2: "net.VIN" }}
+      schX={18}
+      schY={-4}
+      pcbX={17}
+      pcbY={-2.5}
+      connections={{ pin1: "net.VUSB", pin2: "net.VCC5" }}
     />
 
-    {/* Auto-reset */}
-    <capacitor name="C6" capacitance="100nF" footprint="0402"
-      schX={10} schY={-6} pcbX={3} pcbY={-6}
-      connections={{ pin1: "net.DTR_CAP", pin2: "net.RESET" }} />
-    <resistor name="R3" resistance="10kohm" footprint="0402"
-      schX={6} schY={-8} pcbX={1} pcbY={-6}
-      connections={{ pin1: "net.VCC5", pin2: "net.RESET" }} />
+    {/* 16MHz Crystal for ATmega328P */}
+    <chip
+      name="Y1"
+      manufacturerPartNumber="16MHz"
+      footprint="hc49"
+      pinLabels={{ pin1: "XTAL1", pin2: "XTAL2" }}
+      schX={-8}
+      schY={3}
+      pcbX={-15}
+      pcbY={1.8}
+      connections={{ pin1: "net.XTAL16_1", pin2: "net.XTAL16_2" }}
+    />
+    <capacitor
+      name="C1"
+      capacitance="22pF"
+      footprint="0402"
+      schX={-11}
+      schY={5}
+      pcbX={-18}
+      pcbY={2.8}
+      connections={{ pin1: "net.XTAL16_1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C2"
+      capacitance="22pF"
+      footprint="0402"
+      schX={-11}
+      schY={7}
+      pcbX={-18}
+      pcbY={1.2}
+      connections={{ pin1: "net.XTAL16_2", pin2: "net.GND" }}
+    />
 
-    {/* Reset button */}
+    {/* 12MHz Crystal for CH340G */}
+    <chip
+      name="Y2"
+      manufacturerPartNumber="12MHz"
+      footprint="hc49"
+      pinLabels={{ pin1: "XI", pin2: "XO" }}
+      schX={16}
+      schY={4}
+      pcbX={12.5}
+      pcbY={5.4}
+      connections={{ pin1: "net.XTAL12_1", pin2: "net.XTAL12_2" }}
+    />
+    <capacitor
+      name="C3"
+      capacitance="22pF"
+      footprint="0402"
+      schX={19}
+      schY={5}
+      pcbX={14.5}
+      pcbY={5}
+      connections={{ pin1: "net.XTAL12_1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C4"
+      capacitance="22pF"
+      footprint="0402"
+      schX={19}
+      schY={7}
+      pcbX={14.5}
+      pcbY={6}
+      connections={{ pin1: "net.XTAL12_2", pin2: "net.GND" }}
+    />
+
+    {/* Auto-reset: DTR -> 100nF -> RESET */}
+    <capacitor
+      name="C_RESET"
+      capacitance="100nF"
+      footprint="0402"
+      schX={7}
+      schY={-5}
+      pcbX={-10}
+      pcbY={-2.2}
+      connections={{ pin1: "net.DTR", pin2: "net.RESET" }}
+    />
+
+    {/* RESET pull-up 10k to VCC5 */}
+    <resistor
+      name="R_RESET"
+      resistance="10kohm"
+      footprint="0402"
+      schX={4}
+      schY={-5}
+      pcbX={-10}
+      pcbY={-4.2}
+      connections={{ pin1: "net.VCC5", pin2: "net.RESET" }}
+    />
+
+    {/* Reset pushbutton */}
     <pushbutton
-      name="SW1"
+      name="SW_RESET"
       footprint="pushbutton_smd_4mm"
-      schX={6} schY={-12} pcbX={1} pcbY={-10}
-      connections={{ pin1: "net.RESET", pin2: "net.GND" }}
+      pinLabels={{
+        pin1: "RESET_A",
+        pin2: "GND_A",
+        pin3: "RESET_B",
+        pin4: "GND_B",
+      }}
+      schX={4}
+      schY={-8}
+      pcbX={-13}
+      pcbY={-2.5}
+      connections={{
+        pin1: "net.RESET",
+        pin2: "net.GND",
+        pin3: "net.RESET",
+        pin4: "net.GND",
+      }}
     />
 
-    {/* LEDs */}
-    <led name="LED_PWR" color="green" footprint="0402"
-      schX={10} schY={-14} pcbX={3} pcbY={-14}
-      connections={{ anode: "net.VCC5", cathode: "net.LED_PWR_K" }} />
-    <resistor name="R1" resistance="1kohm" footprint="0402"
-      schX={10} schY={-16} pcbX={3} pcbY={-15.5}
-      connections={{ pin1: "net.LED_PWR_K", pin2: "net.GND" }} />
-
-    <led name="LED_TX" color="orange" footprint="0402"
-      schX={14} schY={-14} pcbX={5} pcbY={-14}
-      connections={{ anode: "net.VCC5", cathode: "net.LED_TX_K" }} />
-    <resistor name="R4" resistance="1kohm" footprint="0402"
-      schX={14} schY={-16}
-      connections={{ pin1: "net.LED_TX_K", pin2: sel.U1.pin31 }} />
-
-    <led name="LED_RX" color="orange" footprint="0402"
-      schX={18} schY={-14}
-      connections={{ anode: "net.VCC5", cathode: "net.LED_RX_K" }} />
-    <resistor name="R5" resistance="1kohm" footprint="0402"
-      schX={18} schY={-16}
-      connections={{ pin1: "net.LED_RX_K", pin2: sel.U1.pin30 }} />
-
-    <led name="LED_L" color="yellow" footprint="0402"
-      schX={22} schY={-14}
-      connections={{ anode: "net.LED_L_A", cathode: "net.GND" }} />
-    <resistor name="R6" resistance="1kohm" footprint="0402"
-      schX={22} schY={-16}
-      connections={{ pin1: sel.U1.pin17, pin2: "net.LED_L_A" }} />
-
-    {/* ICSP header */}
+    {/* ICSP 2x3 header */}
     <pinheader
       name="ICSP"
       pinCount={6}
-      rows={2}
-      schX={-8} schY={-10}
-      pcbX={-5} pcbY={-10}
+      doubleRow
+      footprint="pinrow6_rows2_p2.54mm_id1mm_od1.5mm_male"
+      pinLabels={{
+        pin1: "MISO",
+        pin2: "5V",
+        pin3: "SCK",
+        pin4: "MOSI",
+        pin5: "RESET",
+        pin6: "GND",
+      }}
+      schX={-10}
+      schY={-7}
+      pcbX={-13}
+      pcbY={2.8}
       connections={{
-        pin1: sel.U1.pin16,
+        pin1: "net.D12_MISO",
         pin2: "net.VCC5",
-        pin3: sel.U1.pin17,
-        pin4: sel.U1.pin15,
+        pin3: "net.D13_SCK",
+        pin4: "net.D11_MOSI",
         pin5: "net.RESET",
         pin6: "net.GND",
       }}
     />
 
-    {/* JP1: Digital D0-D12 */}
+    {/* Left header: JP1 — digital pins */}
     <pinheader
       name="JP1"
       pinCount={15}
-      schX={-16} schY={0}
-      pcbX={-8} pcbY={0}
+      footprint="pinrow15_p2.54mm_id1mm_od1.5mm_male"
+      pinLabels={{
+        pin1: "D1_TX",
+        pin2: "D0_RX",
+        pin3: "RESET",
+        pin4: "GND",
+        pin5: "D2",
+        pin6: "D3",
+        pin7: "D4",
+        pin8: "D5",
+        pin9: "D6",
+        pin10: "D7",
+        pin11: "D8",
+        pin12: "D9",
+        pin13: "D10_SS",
+        pin14: "D11_MOSI",
+        pin15: "D12_MISO",
+      }}
+      schX={-17}
+      schY={0}
+      pcbX={0}
+      pcbY={-8}
       connections={{
-        pin1:  sel.U1.pin30,
-        pin2:  sel.U1.pin31,
-        pin3:  "net.RESET",
-        pin4:  "net.GND",
-        pin5:  sel.U1.pin32,
-        pin6:  sel.U1.pin1,
-        pin7:  sel.U1.pin2,
-        pin8:  sel.U1.pin9,
-        pin9:  sel.U1.pin10,
-        pin10: sel.U1.pin11,
-        pin11: sel.U1.pin12,
-        pin12: sel.U1.pin13,
-        pin13: sel.U1.pin14,
-        pin14: sel.U1.pin15,
-        pin15: sel.U1.pin16,
+        pin1: "net.D1_TX",
+        pin2: "net.D0_RX",
+        pin3: "net.RESET",
+        pin4: "net.GND",
+        pin5: "net.D2",
+        pin6: "net.D3",
+        pin7: "net.D4",
+        pin8: "net.D5",
+        pin9: "net.D6",
+        pin10: "net.D7",
+        pin11: "net.D8",
+        pin12: "net.D9",
+        pin13: "net.D10_SS",
+        pin14: "net.D11_MOSI",
+        pin15: "net.D12_MISO",
       }}
     />
 
-    {/* JP2: D13 + power + analog */}
+    {/* Right header: JP2 — analog/power */}
     <pinheader
       name="JP2"
       pinCount={15}
-      schX={16} schY={10}
-      pcbX={8} pcbY={0}
+      footprint="pinrow15_p2.54mm_id1mm_od1.5mm_male"
+      pinLabels={{
+        pin1: "VIN",
+        pin2: "GND",
+        pin3: "RESET",
+        pin4: "5V",
+        pin5: "A7",
+        pin6: "A6",
+        pin7: "A5_SCL",
+        pin8: "A4_SDA",
+        pin9: "A3",
+        pin10: "A2",
+        pin11: "A1",
+        pin12: "A0",
+        pin13: "AREF",
+        pin14: "3V3",
+        pin15: "D13_SCK",
+      }}
+      schX={17}
+      schY={0}
+      pcbX={0}
+      pcbY={8}
       connections={{
-        pin1:  sel.U1.pin17,
-        pin2:  "net.VCC3V3",
-        pin3:  "net.AREF",
-        pin4:  sel.U1.pin23,
-        pin5:  sel.U1.pin24,
-        pin6:  sel.U1.pin25,
-        pin7:  sel.U1.pin26,
-        pin8:  sel.U1.pin27,
-        pin9:  sel.U1.pin28,
-        pin10: sel.U1.pin19,
-        pin11: sel.U1.pin22,
-        pin12: "net.VCC5",
-        pin13: "net.RESET",
-        pin14: "net.GND",
-        pin15: "net.VIN",
+        pin1: "net.VIN",
+        pin2: "net.GND",
+        pin3: "net.RESET",
+        pin4: "net.VCC5",
+        pin5: "net.A7",
+        pin6: "net.A6",
+        pin7: "net.A5_SCL",
+        pin8: "net.A4_SDA",
+        pin9: "net.A3",
+        pin10: "net.A2",
+        pin11: "net.A1",
+        pin12: "net.A0",
+        pin13: "net.AREF",
+        pin14: "net.VCC3V3",
+        pin15: "net.D13_SCK",
       }}
     />
 
-    {/* Decoupling caps */}
-    <capacitor name="C3" capacitance="100nF" footprint="0402"
-      schX={6} schY={6}
-      connections={{ pin1: "net.AREF", pin2: "net.GND" }} />
-    <capacitor name="C4" capacitance="100nF" footprint="0402"
-      schX={2} schY={-18}
-      connections={{ pin1: "net.VCC5", pin2: "net.GND" }} />
-    <capacitor name="C5" capacitance="100nF" footprint="0402"
-      schX={4} schY={-18}
-      connections={{ pin1: "net.VCC5", pin2: "net.GND" }} />
+    {/* LEDs: Power (green) */}
+    <resistor
+      name="R_LED_PWR"
+      resistance="1kohm"
+      footprint="0402"
+      schX={4}
+      schY={-12}
+      pcbX={-6}
+      pcbY={-7}
+      connections={{ pin1: "net.VCC5", pin2: "net.LED_PWR_A" }}
+    />
+    <led
+      name="LED_PWR"
+      color="green"
+      footprint="0402"
+      schX={7}
+      schY={-12}
+      pcbX={-5}
+      pcbY={-7}
+      connections={{ anode: "net.LED_PWR_A", cathode: "net.GND" }}
+    />
 
+    {/* LED: TX (orange) */}
+    <resistor
+      name="R_LED_TX"
+      resistance="1kohm"
+      footprint="0402"
+      schX={10}
+      schY={-12}
+      pcbX={-2}
+      pcbY={-7}
+      connections={{ pin1: "net.D1_TX", pin2: "net.LED_TX_A" }}
+    />
+    <led
+      name="LED_TX"
+      color="orange"
+      footprint="0402"
+      schX={13}
+      schY={-12}
+      pcbX={-1}
+      pcbY={-7}
+      connections={{ anode: "net.LED_TX_A", cathode: "net.GND" }}
+    />
+
+    {/* LED: RX (orange) */}
+    <resistor
+      name="R_LED_RX"
+      resistance="1kohm"
+      footprint="0402"
+      schX={16}
+      schY={-12}
+      pcbX={2}
+      pcbY={-7}
+      connections={{ pin1: "net.D0_RX", pin2: "net.LED_RX_A" }}
+    />
+    <led
+      name="LED_RX"
+      color="orange"
+      footprint="0402"
+      schX={19}
+      schY={-12}
+      pcbX={3}
+      pcbY={-7}
+      connections={{ anode: "net.LED_RX_A", cathode: "net.GND" }}
+    />
+
+    {/* LED: L/D13 (yellow) */}
+    <resistor
+      name="R_LED_L"
+      resistance="1kohm"
+      footprint="0402"
+      schX={22}
+      schY={-12}
+      pcbX={6}
+      pcbY={-7}
+      connections={{ pin1: "net.D13_SCK", pin2: "net.LED_L_A" }}
+    />
+    <led
+      name="LED_L"
+      color="yellow"
+      footprint="0402"
+      schX={25}
+      schY={-12}
+      pcbX={7}
+      pcbY={-7}
+      connections={{ anode: "net.LED_L_A", cathode: "net.GND" }}
+    />
+
+    {/* Decoupling caps */}
+    <capacitor
+      name="C_AREF"
+      capacitance="100nF"
+      footprint="0402"
+      schX={-5}
+      schY={7}
+      pcbX={-8}
+      pcbY={3.8}
+      connections={{ pin1: "net.AREF", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_VCC1"
+      capacitance="100nF"
+      footprint="0402"
+      schX={-2}
+      schY={7}
+      pcbX={-8}
+      pcbY={2.6}
+      connections={{ pin1: "net.VCC5", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_AVCC"
+      capacitance="100nF"
+      footprint="0402"
+      schX={1}
+      schY={7}
+      pcbX={-8}
+      pcbY={1.4}
+      connections={{ pin1: "net.VCC5", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_USB"
+      capacitance="100nF"
+      footprint="0402"
+      schX={22}
+      schY={3}
+      pcbX={18}
+      pcbY={3.5}
+      connections={{ pin1: "net.VUSB", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_VIN_BULK"
+      capacitance="10uF"
+      footprint="0805"
+      schX={16}
+      schY={-7}
+      pcbX={14}
+      pcbY={-4.5}
+      connections={{ pin1: "net.VIN", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_5V_OUT"
+      capacitance="10uF"
+      footprint="0805"
+      schX={16}
+      schY={-9}
+      pcbX={14}
+      pcbY={-6.5}
+      connections={{ pin1: "net.VCC5", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_3V3_OUT"
+      capacitance="10uF"
+      footprint="0805"
+      schX={16}
+      schY={-11}
+      pcbX={19}
+      pcbY={-6.5}
+      connections={{ pin1: "net.VCC3V3", pin2: "net.GND" }}
+    />
   </board>
 )
 

--- a/snippets/arduino-nano.tsx
+++ b/snippets/arduino-nano.tsx
@@ -94,31 +94,31 @@ const CH340G = (props: any) => (
     manufacturerPartNumber="CH340G"
     footprint="soic16_w3.9mm_p1.27mm"
     pinLabels={{
-      pin1: "TXD",
-      pin2: "RXD",
-      pin3: "V3",
-      pin4: "UD_PLUS",
-      pin5: "UD_MINUS",
-      pin6: "XI",
-      pin7: "XO",
-      pin8: "TEST",
-      pin9: "GND",
-      pin10: "CTS",
-      pin11: "DSR",
-      pin12: "RI",
-      pin13: "DCD",
-      pin14: "DTR",
-      pin15: "RTS",
+      pin1: "GND",
+      pin2: "TXD",
+      pin3: "RXD",
+      pin4: "V3",
+      pin5: "UD_PLUS",
+      pin6: "UD_MINUS",
+      pin7: "XI",
+      pin8: "XO",
+      pin9: "CTS",
+      pin10: "DSR",
+      pin11: "RI",
+      pin12: "DCD",
+      pin13: "DTR",
+      pin14: "RTS",
+      pin15: "R232",
       pin16: "VCC",
     }}
     schPinArrangement={{
       leftSide: {
         direction: "top-to-bottom",
-        pins: ["pin16", "pin3", "pin6", "pin7", "pin4", "pin5", "pin8", "pin9"],
+        pins: ["pin16", "pin4", "pin7", "pin8", "pin5", "pin6", "pin15", "pin1"],
       },
       rightSide: {
         direction: "top-to-bottom",
-        pins: ["pin1", "pin2", "pin14", "pin15", "pin10", "pin11", "pin12", "pin13"],
+        pins: ["pin2", "pin3", "pin13", "pin14", "pin9", "pin10", "pin11", "pin12"],
       },
     }}
     {...props}
@@ -216,20 +216,20 @@ export const ArduinoNano = () => (
       pcbX={11}
       pcbY={1.5}
       connections={{
-        pin1: "net.D0_RX",
+        pin1: "net.GND",
         pin2: "net.D1_TX",
-        pin3: "net.VCC3V3",
-        pin4: "net.USB_D_PLUS",
-        pin5: "net.USB_D_MINUS",
-        pin6: "net.XTAL12_1",
-        pin7: "net.XTAL12_2",
-        pin8: "net.GND",
+        pin3: "net.D0_RX",
+        pin4: "net.VCC3V3",
+        pin5: "net.USB_D_PLUS",
+        pin6: "net.USB_D_MINUS",
+        pin7: "net.XTAL12_1",
+        pin8: "net.XTAL12_2",
         pin9: "net.GND",
         pin10: "net.GND",
         pin11: "net.GND",
         pin12: "net.GND",
-        pin13: "net.GND",
-        pin14: "net.DTR",
+        pin13: "net.DTR",
+        pin14: "net.RTS",
         pin15: "net.GND",
         pin16: "net.VCC5",
       }}
@@ -697,3 +697,4 @@ export const ArduinoNano = () => (
 )
 
 export default ArduinoNano
+

--- a/snippets/arduino-nano.tsx
+++ b/snippets/arduino-nano.tsx
@@ -1,0 +1,378 @@
+import { sel } from "tscircuit"
+
+/**
+ * Arduino Nano V3.0 (ATmega328P)
+ *
+ * Based on the official Arduino Nano schematic.
+ * - MCU: ATmega328P (TQFP-32)
+ * - USB-Serial: CH340G
+ * - Regulator: AMS1117-5.0 (5V) + AMS1117-3.3 (3.3V)
+ * - Clock: 16 MHz crystal
+ * - Auto-reset via DTR -> 100nF -> RESET
+ *
+ * For tscircuit/tscircuit issue #328
+ * https://github.com/tscircuit/tscircuit/issues/328
+ */
+
+const ATmega328P = (props: any) => (
+  <chip
+    manufacturerPartNumber="ATmega328P-AU"
+    pinLabels={{
+      pin1: "PD3",
+      pin2: "PD4",
+      pin3: "GND",
+      pin4: "VCC",
+      pin5: "GND2",
+      pin6: "VCC2",
+      pin7: "XTAL1",
+      pin8: "XTAL2",
+      pin9: "PD5",
+      pin10: "PD6",
+      pin11: "PD7",
+      pin12: "PB0",
+      pin13: "PB1",
+      pin14: "PB2",
+      pin15: "PB3",
+      pin16: "PB4",
+      pin17: "PB5",
+      pin18: "AVCC",
+      pin19: "ADC6",
+      pin20: "AREF",
+      pin21: "GND3",
+      pin22: "ADC7",
+      pin23: "PC0",
+      pin24: "PC1",
+      pin25: "PC2",
+      pin26: "PC3",
+      pin27: "PC4",
+      pin28: "PC5",
+      pin29: "PC6",
+      pin30: "PD0",
+      pin31: "PD1",
+      pin32: "PD2",
+    }}
+    schPinArrangement={{
+      leftSide: {
+        direction: "top-to-bottom",
+        pins: [
+          "pin30", "pin31", "pin32", "pin1", "pin2",
+          "pin9", "pin10", "pin11", "pin12", "pin13",
+          "pin14", "pin15", "pin16", "pin17", "pin29",
+        ],
+      },
+      rightSide: {
+        direction: "top-to-bottom",
+        pins: [
+          "pin23", "pin24", "pin25", "pin26", "pin27", "pin28",
+          "pin19", "pin22", "pin20", "pin18",
+          "pin7", "pin8",
+        ],
+      },
+      topSide: {
+        direction: "left-to-right",
+        pins: ["pin4", "pin6"],
+      },
+      bottomSide: {
+        direction: "left-to-right",
+        pins: ["pin3", "pin5", "pin21"],
+      },
+    }}
+    {...props}
+  />
+)
+
+const CH340G = (props: any) => (
+  <chip
+    manufacturerPartNumber="CH340G"
+    pinLabels={{
+      pin1: "TXD",
+      pin2: "RXD",
+      pin3: "V3",
+      pin4: "UD_PLUS",
+      pin5: "UD_MINUS",
+      pin6: "XI",
+      pin7: "XO",
+      pin8: "TEST",
+      pin9: "GND",
+      pin10: "CTS",
+      pin11: "DSR",
+      pin12: "RI",
+      pin13: "DCD",
+      pin14: "DTR",
+      pin15: "RTS",
+      pin16: "VCC",
+    }}
+    schPinArrangement={{
+      leftSide: {
+        direction: "top-to-bottom",
+        pins: ["pin16", "pin6", "pin7", "pin3", "pin4", "pin5", "pin8", "pin9"],
+      },
+      rightSide: {
+        direction: "top-to-bottom",
+        pins: ["pin1", "pin2", "pin14", "pin15", "pin10", "pin11", "pin12", "pin13"],
+      },
+    }}
+    {...props}
+  />
+)
+
+const AMS1117_5V = (props: any) => (
+  <chip
+    manufacturerPartNumber="AMS1117-5.0"
+    pinLabels={{
+      pin1: "ADJ_GND",
+      pin2: "OUT",
+      pin3: "IN",
+      pin4: "OUT2",
+    }}
+    {...props}
+  />
+)
+
+const AMS1117_3V3 = (props: any) => (
+  <chip
+    manufacturerPartNumber="AMS1117-3.3"
+    pinLabels={{
+      pin1: "ADJ_GND",
+      pin2: "OUT",
+      pin3: "IN",
+      pin4: "OUT2",
+    }}
+    {...props}
+  />
+)
+
+export const ArduinoNano = () => (
+  <board width="18mm" height="46mm" autorouter="auto-cloud">
+
+    {/* MCU */}
+    <ATmega328P
+      name="U1"
+      footprint="tqfp32_p0.8mm"
+      schX={0} schY={0}
+      pcbX={0} pcbY={0}
+      connections={{
+        pin30: sel.U2.pin2,
+        pin31: sel.U2.pin1,
+        pin4: "net.VCC5",
+        pin6: "net.VCC5",
+        pin18: "net.VCC5",
+        pin3: "net.GND",
+        pin5: "net.GND",
+        pin21: "net.GND",
+        pin7: sel.Y1.pin1,
+        pin8: sel.Y1.pin2,
+        pin29: "net.RESET",
+        pin15: sel.ICSP.pin4,
+        pin16: sel.ICSP.pin1,
+        pin17: sel.ICSP.pin3,
+      }}
+    />
+
+    {/* USB-Serial bridge */}
+    <CH340G
+      name="U2"
+      footprint="soic16_p1.27mm"
+      schX={16} schY={0}
+      pcbX={7} pcbY={0}
+      connections={{
+        pin3: "net.VCC3V3",
+        pin8: "net.GND",
+        pin9: "net.GND",
+        pin14: "net.DTR_CAP",
+        pin16: "net.VCC5",
+      }}
+    />
+
+    {/* 16 MHz Crystal */}
+    <chip
+      name="Y1"
+      manufacturerPartNumber="16MHz_Crystal"
+      footprint="crystal_hc49s_p4.88mm"
+      pinLabels={{ pin1: "IN", pin2: "OUT" }}
+      schX={-8} schY={4}
+      pcbX={-4} pcbY={4}
+    />
+    <capacitor name="C1" capacitance="22pF" footprint="0402"
+      schX={-12} schY={6} pcbX={-4} pcbY={5.5}
+      connections={{ pin1: sel.Y1.pin1, pin2: "net.GND" }} />
+    <capacitor name="C2" capacitance="22pF" footprint="0402"
+      schX={-12} schY={8} pcbX={-4} pcbY={6.5}
+      connections={{ pin1: sel.Y1.pin2, pin2: "net.GND" }} />
+
+    {/* 5V LDO */}
+    <AMS1117_5V
+      name="U3"
+      footprint="sot223"
+      schX={16} schY={-10}
+      pcbX={7} pcbY={-8}
+      connections={{ pin1: "net.GND", pin2: "net.VCC5", pin3: "net.VIN", pin4: "net.VCC5" }}
+    />
+    <capacitor name="C7" capacitance="10uF" footprint="0805"
+      schX={20} schY={-10} pcbX={9} pcbY={-8}
+      connections={{ pin1: "net.VIN", pin2: "net.GND" }} />
+    <capacitor name="C8" capacitance="10uF" footprint="0805"
+      schX={20} schY={-12} pcbX={9} pcbY={-6}
+      connections={{ pin1: "net.VCC5", pin2: "net.GND" }} />
+
+    {/* 3.3V LDO */}
+    <AMS1117_3V3
+      name="U4"
+      footprint="sot223"
+      schX={16} schY={-16}
+      pcbX={7} pcbY={-12}
+      connections={{ pin1: "net.GND", pin2: "net.VCC3V3", pin3: "net.VCC5", pin4: "net.VCC3V3" }}
+    />
+    <capacitor name="C9" capacitance="10uF" footprint="0805"
+      schX={20} schY={-16} pcbX={9} pcbY={-12}
+      connections={{ pin1: "net.VCC3V3", pin2: "net.GND" }} />
+
+    {/* USB Mini-B */}
+    <chip
+      name="J1"
+      manufacturerPartNumber="USB_MINI_B"
+      footprint="usb_mini_b_p2.0mm"
+      pinLabels={{ pin1: "VBUS", pin2: "D_MINUS", pin3: "D_PLUS", pin4: "ID", pin5: "GND" }}
+      schX={24} schY={4}
+      pcbX={9} pcbY={18}
+      connections={{ pin1: "net.VUSB", pin2: sel.U2.pin5, pin3: sel.U2.pin4, pin5: "net.GND" }}
+    />
+    <capacitor name="C10" capacitance="100nF" footprint="0402"
+      schX={24} schY={2}
+      connections={{ pin1: "net.VUSB", pin2: "net.GND" }} />
+    <chip
+      name="D5"
+      manufacturerPartNumber="B5819W"
+      footprint="sod123"
+      pinLabels={{ pin1: "A", pin2: "K" }}
+      schX={22} schY={-2}
+      connections={{ pin1: "net.VUSB", pin2: "net.VIN" }}
+    />
+
+    {/* Auto-reset */}
+    <capacitor name="C6" capacitance="100nF" footprint="0402"
+      schX={10} schY={-6} pcbX={3} pcbY={-6}
+      connections={{ pin1: "net.DTR_CAP", pin2: "net.RESET" }} />
+    <resistor name="R3" resistance="10kohm" footprint="0402"
+      schX={6} schY={-8} pcbX={1} pcbY={-6}
+      connections={{ pin1: "net.VCC5", pin2: "net.RESET" }} />
+
+    {/* Reset button */}
+    <pushbutton
+      name="SW1"
+      footprint="pushbutton_smd_4mm"
+      schX={6} schY={-12} pcbX={1} pcbY={-10}
+      connections={{ pin1: "net.RESET", pin2: "net.GND" }}
+    />
+
+    {/* LEDs */}
+    <led name="LED_PWR" color="green" footprint="0402"
+      schX={10} schY={-14} pcbX={3} pcbY={-14}
+      connections={{ anode: "net.VCC5", cathode: "net.LED_PWR_K" }} />
+    <resistor name="R1" resistance="1kohm" footprint="0402"
+      schX={10} schY={-16} pcbX={3} pcbY={-15.5}
+      connections={{ pin1: "net.LED_PWR_K", pin2: "net.GND" }} />
+
+    <led name="LED_TX" color="orange" footprint="0402"
+      schX={14} schY={-14} pcbX={5} pcbY={-14}
+      connections={{ anode: "net.VCC5", cathode: "net.LED_TX_K" }} />
+    <resistor name="R4" resistance="1kohm" footprint="0402"
+      schX={14} schY={-16}
+      connections={{ pin1: "net.LED_TX_K", pin2: sel.U1.pin31 }} />
+
+    <led name="LED_RX" color="orange" footprint="0402"
+      schX={18} schY={-14}
+      connections={{ anode: "net.VCC5", cathode: "net.LED_RX_K" }} />
+    <resistor name="R5" resistance="1kohm" footprint="0402"
+      schX={18} schY={-16}
+      connections={{ pin1: "net.LED_RX_K", pin2: sel.U1.pin30 }} />
+
+    <led name="LED_L" color="yellow" footprint="0402"
+      schX={22} schY={-14}
+      connections={{ anode: "net.LED_L_A", cathode: "net.GND" }} />
+    <resistor name="R6" resistance="1kohm" footprint="0402"
+      schX={22} schY={-16}
+      connections={{ pin1: sel.U1.pin17, pin2: "net.LED_L_A" }} />
+
+    {/* ICSP header */}
+    <pinheader
+      name="ICSP"
+      pinCount={6}
+      rows={2}
+      schX={-8} schY={-10}
+      pcbX={-5} pcbY={-10}
+      connections={{
+        pin1: sel.U1.pin16,
+        pin2: "net.VCC5",
+        pin3: sel.U1.pin17,
+        pin4: sel.U1.pin15,
+        pin5: "net.RESET",
+        pin6: "net.GND",
+      }}
+    />
+
+    {/* JP1: Digital D0-D12 */}
+    <pinheader
+      name="JP1"
+      pinCount={15}
+      schX={-16} schY={0}
+      pcbX={-8} pcbY={0}
+      connections={{
+        pin1:  sel.U1.pin30,
+        pin2:  sel.U1.pin31,
+        pin3:  "net.RESET",
+        pin4:  "net.GND",
+        pin5:  sel.U1.pin32,
+        pin6:  sel.U1.pin1,
+        pin7:  sel.U1.pin2,
+        pin8:  sel.U1.pin9,
+        pin9:  sel.U1.pin10,
+        pin10: sel.U1.pin11,
+        pin11: sel.U1.pin12,
+        pin12: sel.U1.pin13,
+        pin13: sel.U1.pin14,
+        pin14: sel.U1.pin15,
+        pin15: sel.U1.pin16,
+      }}
+    />
+
+    {/* JP2: D13 + power + analog */}
+    <pinheader
+      name="JP2"
+      pinCount={15}
+      schX={16} schY={10}
+      pcbX={8} pcbY={0}
+      connections={{
+        pin1:  sel.U1.pin17,
+        pin2:  "net.VCC3V3",
+        pin3:  "net.AREF",
+        pin4:  sel.U1.pin23,
+        pin5:  sel.U1.pin24,
+        pin6:  sel.U1.pin25,
+        pin7:  sel.U1.pin26,
+        pin8:  sel.U1.pin27,
+        pin9:  sel.U1.pin28,
+        pin10: sel.U1.pin19,
+        pin11: sel.U1.pin22,
+        pin12: "net.VCC5",
+        pin13: "net.RESET",
+        pin14: "net.GND",
+        pin15: "net.VIN",
+      }}
+    />
+
+    {/* Decoupling caps */}
+    <capacitor name="C3" capacitance="100nF" footprint="0402"
+      schX={6} schY={6}
+      connections={{ pin1: "net.AREF", pin2: "net.GND" }} />
+    <capacitor name="C4" capacitance="100nF" footprint="0402"
+      schX={2} schY={-18}
+      connections={{ pin1: "net.VCC5", pin2: "net.GND" }} />
+    <capacitor name="C5" capacitance="100nF" footprint="0402"
+      schX={4} schY={-18}
+      connections={{ pin1: "net.VCC5", pin2: "net.GND" }} />
+
+  </board>
+)
+
+export default ArduinoNano

--- a/snippets/arduino-nano.tsx
+++ b/snippets/arduino-nano.tsx
@@ -138,6 +138,13 @@ const AMS1117 = (props: any) => (
   />
 )
 
+const Crystal = (props: any) => (
+  <chip
+    footprint="hc49"
+    pinLabels={{ pin1: props.leftPin, pin2: props.rightPin }}
+    {...props}
+  />
+)
 export const ArduinoNano = () => (
   <board width="45mm" height="18mm" autorouterEffortLevel="100x">
     {/* GND copper pours on both layers */}
@@ -298,11 +305,11 @@ export const ArduinoNano = () => (
     />
 
     {/* 16MHz Crystal for ATmega328P */}
-    <chip
+    <Crystal
       name="Y1"
-      manufacturerPartNumber="16MHz"
-      footprint="hc49"
-      pinLabels={{ pin1: "XTAL1", pin2: "XTAL2" }}
+      manufacturerPartNumber="16MHz Crystal"
+      leftPin="XTAL1"
+      rightPin="XTAL2"
       schX={-8}
       schY={3}
       pcbX={-15}
@@ -331,11 +338,11 @@ export const ArduinoNano = () => (
     />
 
     {/* 12MHz Crystal for CH340G */}
-    <chip
+    <Crystal
       name="Y2"
-      manufacturerPartNumber="12MHz"
-      footprint="hc49"
-      pinLabels={{ pin1: "XI", pin2: "XO" }}
+      manufacturerPartNumber="12MHz Crystal"
+      leftPin="XI"
+      rightPin="XO"
       schX={16}
       schY={4}
       pcbX={12.5}

--- a/tests/test-arduino-nano.tsx
+++ b/tests/test-arduino-nano.tsx
@@ -1,58 +1,185 @@
-import React from "react"
-import { test, expect } from "bun:test"
+import { expect, test } from "bun:test"
 import { Circuit } from "../dist"
 import { ArduinoNano } from "../snippets/arduino-nano"
 
-test("Arduino Nano compiles to circuit JSON", async () => {
+type SoupElement = Record<string, any>
+
+const renderArduinoNano = () => {
   const circuit = new Circuit()
   circuit.add(<ArduinoNano />)
   circuit.render()
+  return circuit.getCircuitJson() as SoupElement[]
+}
 
-  const circuitJson = circuit.getCircuitJson()
-  expect(Array.isArray(circuitJson)).toBe(true)
-  expect(circuitJson.length).toBeGreaterThan(0)
-})
+const byName = (soup: SoupElement[], name: string) => {
+  const component = soup.find(
+    (element) => element.type === "source_component" && element.name === name,
+  )
+  expect(component, `missing source component ${name}`).toBeDefined()
+  return component!
+}
 
-test("Arduino Nano board dimensions are 45mm x 18mm", async () => {
-  const circuit = new Circuit()
-  circuit.add(<ArduinoNano />)
-  circuit.render()
+const portsFor = (soup: SoupElement[], componentName: string) => {
+  const component = byName(soup, componentName)
+  return soup.filter(
+    (element) =>
+      element.type === "source_port" &&
+      element.source_component_id === component.source_component_id,
+  )
+}
 
-  const circuitJson = circuit.getCircuitJson()
-  const board = circuitJson.find((item: any) => item.type === "pcb_board")
-  expect(board).toBeDefined()
+const port = (soup: SoupElement[], componentName: string, label: string) => {
+  const match = portsFor(soup, componentName).find((sourcePort) =>
+    sourcePort.port_hints?.includes(label),
+  )
+  expect(match, `missing ${componentName}.${label}`).toBeDefined()
+  return match!
+}
+
+const netKey = (soup: SoupElement[], componentName: string, label: string) =>
+  port(soup, componentName, label).subcircuit_connectivity_map_key
+
+const expectSharedNet = (
+  soup: SoupElement[],
+  left: [string, string],
+  right: [string, string],
+) => {
+  expect(netKey(soup, ...left), `${left.join(".")} net`).toBe(
+    netKey(soup, ...right),
+  )
+}
+
+const sourceNet = (soup: SoupElement[], name: string) => {
+  const net = soup.find(
+    (element) => element.type === "source_net" && element.name === name,
+  )
+  expect(net, `missing source net ${name}`).toBeDefined()
+  return net!
+}
+
+test("Arduino Nano has correct board dimensions (45mm × 18mm)", () => {
+  const soup = renderArduinoNano()
+  const board = soup.find((element) => element.type === "pcb_board")
+
   expect(board?.width).toBe(45)
   expect(board?.height).toBe(18)
 })
 
-test("Arduino Nano has expected ICs: ATmega328P, CH340G, and regulators", async () => {
-  const circuit = new Circuit()
-  circuit.add(<ArduinoNano />)
-  circuit.render()
+test("Arduino Nano has all major ICs and connectors", () => {
+  const soup = renderArduinoNano()
 
-  const circuitJson = circuit.getCircuitJson()
-  const components = circuitJson.filter(
-    (item: any) => item.type === "source_component",
-  )
+  expect(byName(soup, "U1").manufacturer_part_number).toBe("ATmega328P-AU")
+  expect(byName(soup, "U2").manufacturer_part_number).toBe("CH340G")
+  expect(byName(soup, "U3").manufacturer_part_number).toBe("AMS1117-5.0")
+  expect(byName(soup, "U4").manufacturer_part_number).toBe("AMS1117-3.3")
+  expect(byName(soup, "J_USB").manufacturer_part_number).toBe("USB-MINI-B")
 
-  const names = components.map((c: any) => c.name)
-  expect(names).toContain("U1")
-  expect(names).toContain("U2")
-  expect(names).toContain("U3")
-  expect(names).toContain("U4")
+  for (const name of ["LED_PWR", "LED_TX", "LED_RX", "LED_L"]) {
+    expect(byName(soup, name)).toBeDefined()
+  }
 })
 
-test("Arduino Nano has crystal oscillators Y1 and Y2", async () => {
-  const circuit = new Circuit()
-  circuit.add(<ArduinoNano />)
-  circuit.render()
+test("Arduino Nano has dual clock domains: 16MHz for MCU and 12MHz for CH340G", () => {
+  const soup = renderArduinoNano()
 
-  const circuitJson = circuit.getCircuitJson()
-  const components = circuitJson.filter(
-    (item: any) => item.type === "source_component",
-  )
+  expect(byName(soup, "Y1").manufacturer_part_number).toBe("16MHz")
+  expect(byName(soup, "Y2").manufacturer_part_number).toBe("12MHz")
 
-  const names = components.map((c: any) => c.name)
-  expect(names).toContain("Y1")
-  expect(names).toContain("Y2")
+  // 16MHz crystal wired to ATmega328P XTAL pins
+  expectSharedNet(soup, ["U1", "XTAL1"], ["Y1", "XTAL1"])
+  expectSharedNet(soup, ["U1", "XTAL2"], ["Y1", "XTAL2"])
+
+  // 12MHz crystal wired to CH340G XI/XO pins
+  expectSharedNet(soup, ["U2", "XI"], ["Y2", "XI"])
+  expectSharedNet(soup, ["U2", "XO"], ["Y2", "XO"])
+
+  // Load capacitors on both crystals
+  expectSharedNet(soup, ["C1", "pin1"], ["Y1", "XTAL1"])
+  expectSharedNet(soup, ["C2", "pin1"], ["Y1", "XTAL2"])
+  expectSharedNet(soup, ["C3", "pin1"], ["Y2", "XI"])
+  expectSharedNet(soup, ["C4", "pin1"], ["Y2", "XO"])
+})
+
+test("Arduino Nano exposes standard dual 15-pin public header map (JP1 + JP2)", () => {
+  const soup = renderArduinoNano()
+
+  const jp1Labels = portsFor(soup, "JP1").map((p) => p.name)
+  const jp2Labels = portsFor(soup, "JP2").map((p) => p.name)
+
+  expect(jp1Labels).toEqual([
+    "D1_TX",
+    "D0_RX",
+    "RESET",
+    "GND",
+    "D2",
+    "D3",
+    "D4",
+    "D5",
+    "D6",
+    "D7",
+    "D8",
+    "D9",
+    "D10_SS",
+    "D11_MOSI",
+    "D12_MISO",
+  ])
+  expect(jp2Labels).toEqual([
+    "VIN",
+    "GND",
+    "RESET",
+    "5V",
+    "A7",
+    "A6",
+    "A5_SCL",
+    "A4_SDA",
+    "A3",
+    "A2",
+    "A1",
+    "A0",
+    "AREF",
+    "3V3",
+    "D13_SCK",
+  ])
+})
+
+test("Arduino Nano connects serial, reset, ICSP, analog, and power nets", () => {
+  const soup = renderArduinoNano()
+
+  // Serial: CH340G TXD -> MCU RX, CH340G RXD -> MCU TX
+  expectSharedNet(soup, ["JP1", "D0_RX"], ["U1", "D0_RX"])
+  expectSharedNet(soup, ["JP1", "D1_TX"], ["U1", "D1_TX"])
+  expectSharedNet(soup, ["U2", "TXD"], ["U1", "D0_RX"])
+  expectSharedNet(soup, ["U2", "RXD"], ["U1", "D1_TX"])
+
+  // Auto-reset: CH340G DTR -> 100nF cap -> RESET
+  expectSharedNet(soup, ["U2", "DTR"], ["C_RESET", "pin1"])
+  expectSharedNet(soup, ["C_RESET", "pin2"], ["U1", "RESET"])
+  expectSharedNet(soup, ["SW_RESET", "pin1"], ["U1", "RESET"])
+
+  // ICSP header
+  expectSharedNet(soup, ["ICSP", "MISO"], ["U1", "D12_MISO"])
+  expectSharedNet(soup, ["ICSP", "MOSI"], ["U1", "D11_MOSI"])
+  expectSharedNet(soup, ["ICSP", "SCK"], ["U1", "D13_SCK"])
+  expectSharedNet(soup, ["ICSP", "RESET"], ["U1", "RESET"])
+
+  // Analog pins
+  expectSharedNet(soup, ["JP2", "A0"], ["U1", "A0"])
+  expectSharedNet(soup, ["JP2", "A7"], ["U1", "A7"])
+  expectSharedNet(soup, ["JP2", "AREF"], ["U1", "AREF"])
+
+  // USB differential pair
+  expectSharedNet(soup, ["J_USB", "D_PLUS"], ["U2", "UD_PLUS"])
+  expectSharedNet(soup, ["J_USB", "D_MINUS"], ["U2", "UD_MINUS"])
+
+  // Power rails present
+  for (const netName of ["VIN", "VUSB", "VCC5", "VCC3V3", "GND"]) {
+    sourceNet(soup, netName)
+  }
+
+  // Regulator outputs at headers
+  expectSharedNet(soup, ["JP2", "5V"], ["U3", "OUT"])
+  expectSharedNet(soup, ["JP2", "3V3"], ["U4", "OUT"])
+
+  // D13 LED
+  expectSharedNet(soup, ["R_LED_L", "pin1"], ["U1", "D13_SCK"])
 })

--- a/tests/test-arduino-nano.tsx
+++ b/tests/test-arduino-nano.tsx
@@ -164,28 +164,27 @@ test("Arduino Nano exposes standard dual 15-pin public header map (JP1 + JP2)", 
 
 test("Arduino Nano maps CH340G SOIC-16 pins to the correct physical nets", () => {
   const soup = renderArduinoNano()
-  // CH340G SOIC-16 pinmap: [pinNumber, pinLabel, connectedComponent, connectedPin]
-  // pin1=TXD→U1.D0_RX, pin2=RXD→U1.D1_TX, pin3=V3→VCC3V3,
-  // pin4=UD_PLUS→J_USB.D_PLUS, pin5=UD_MINUS→J_USB.D_MINUS,
-  // pin6=XI→Y2.XI, pin7=XO→Y2.XO, pin8=TEST→GND,
-  // pin9=GND→GND, pin10-13=CTS/DSR/RI/DCD→GND, pin14=DTR→C_RESET.pin1,
-  // pin15=RTS→GND, pin16=VCC→VCC5
+  // CH340G SOIC-16 pinmap per WCH datasheet
+  // pin1=GND, pin2=TXD→U1.D0_RX, pin3=RXD→U1.D1_TX, pin4=V3→VCC3V3,
+  // pin5=UD_PLUS→J_USB.D_PLUS, pin6=UD_MINUS→J_USB.D_MINUS,
+  // pin7=XI→Y2.XI, pin8=XO→Y2.XO, pin9-12=CTS/DSR/RI/DCD→GND,
+  // pin13=DTR→C_RESET.pin1, pin14=RTS→GND, pin15=R232→GND, pin16=VCC→VCC5
   const expectedPinLabels: Array<[number, string]> = [
-    [1, "TXD"],
-    [2, "RXD"],
-    [3, "V3"],
-    [4, "UD_PLUS"],
-    [5, "UD_MINUS"],
-    [6, "XI"],
-    [7, "XO"],
-    [8, "TEST"],
-    [9, "GND"],
-    [10, "CTS"],
-    [11, "DSR"],
-    [12, "RI"],
-    [13, "DCD"],
-    [14, "DTR"],
-    [15, "RTS"],
+    [1, "GND"],
+    [2, "TXD"],
+    [3, "RXD"],
+    [4, "V3"],
+    [5, "UD_PLUS"],
+    [6, "UD_MINUS"],
+    [7, "XI"],
+    [8, "XO"],
+    [9, "CTS"],
+    [10, "DSR"],
+    [11, "RI"],
+    [12, "DCD"],
+    [13, "DTR"],
+    [14, "RTS"],
+    [15, "R232"],
     [16, "VCC"],
   ]
   for (const [pinNumber, label] of expectedPinLabels) {
@@ -194,32 +193,32 @@ test("Arduino Nano maps CH340G SOIC-16 pins to the correct physical nets", () =>
   }
   // Verify key net connections via pin number
   expect(
-    netKeyByPinNumber(soup, "U2", 1),
-    "U2 pin1 TXD → U1.D0_RX",
+    netKeyByPinNumber(soup, "U2", 2),
+    "U2 pin2 TXD → U1.D0_RX",
   ).toBe(netKey(soup, "U1", "D0_RX"))
   expect(
-    netKeyByPinNumber(soup, "U2", 2),
-    "U2 pin2 RXD → U1.D1_TX",
+    netKeyByPinNumber(soup, "U2", 3),
+    "U2 pin3 RXD → U1.D1_TX",
   ).toBe(netKey(soup, "U1", "D1_TX"))
   expect(
-    netKeyByPinNumber(soup, "U2", 4),
-    "U2 pin4 UD_PLUS → J_USB.D_PLUS",
+    netKeyByPinNumber(soup, "U2", 5),
+    "U2 pin5 UD_PLUS → J_USB.D_PLUS",
   ).toBe(netKey(soup, "J_USB", "D_PLUS"))
   expect(
-    netKeyByPinNumber(soup, "U2", 5),
-    "U2 pin5 UD_MINUS → J_USB.D_MINUS",
+    netKeyByPinNumber(soup, "U2", 6),
+    "U2 pin6 UD_MINUS → J_USB.D_MINUS",
   ).toBe(netKey(soup, "J_USB", "D_MINUS"))
   expect(
-    netKeyByPinNumber(soup, "U2", 6),
-    "U2 pin6 XI → Y2.XI",
+    netKeyByPinNumber(soup, "U2", 7),
+    "U2 pin7 XI → Y2.XI",
   ).toBe(netKey(soup, "Y2", "XI"))
   expect(
-    netKeyByPinNumber(soup, "U2", 7),
-    "U2 pin7 XO → Y2.XO",
+    netKeyByPinNumber(soup, "U2", 8),
+    "U2 pin8 XO → Y2.XO",
   ).toBe(netKey(soup, "Y2", "XO"))
   expect(
-    netKeyByPinNumber(soup, "U2", 14),
-    "U2 pin14 DTR → C_RESET.pin1",
+    netKeyByPinNumber(soup, "U2", 13),
+    "U2 pin13 DTR → C_RESET.pin1",
   ).toBe(netKey(soup, "C_RESET", "pin1"))
 })
 
@@ -256,3 +255,4 @@ test("Arduino Nano connects serial, reset, ICSP, analog, and power nets", () => 
   // D13 LED driven by ATmega D13_SCK via current-limiting resistor
   expectSharedNet(soup, ["R_LED_L", "pin1"], ["U1", "D13_SCK"])
 })
+

--- a/tests/test-arduino-nano.tsx
+++ b/tests/test-arduino-nano.tsx
@@ -1,0 +1,58 @@
+import React from "react"
+import { test, expect } from "bun:test"
+import { Circuit } from "../dist"
+import { ArduinoNano } from "../snippets/arduino-nano"
+
+test("Arduino Nano compiles to circuit JSON", async () => {
+  const circuit = new Circuit()
+  circuit.add(<ArduinoNano />)
+  circuit.render()
+
+  const circuitJson = circuit.getCircuitJson()
+  expect(Array.isArray(circuitJson)).toBe(true)
+  expect(circuitJson.length).toBeGreaterThan(0)
+})
+
+test("Arduino Nano board dimensions are 45mm x 18mm", async () => {
+  const circuit = new Circuit()
+  circuit.add(<ArduinoNano />)
+  circuit.render()
+
+  const circuitJson = circuit.getCircuitJson()
+  const board = circuitJson.find((item: any) => item.type === "pcb_board")
+  expect(board).toBeDefined()
+  expect(board?.width).toBe(45)
+  expect(board?.height).toBe(18)
+})
+
+test("Arduino Nano has expected ICs: ATmega328P, CH340G, and regulators", async () => {
+  const circuit = new Circuit()
+  circuit.add(<ArduinoNano />)
+  circuit.render()
+
+  const circuitJson = circuit.getCircuitJson()
+  const components = circuitJson.filter(
+    (item: any) => item.type === "source_component",
+  )
+
+  const names = components.map((c: any) => c.name)
+  expect(names).toContain("U1")
+  expect(names).toContain("U2")
+  expect(names).toContain("U3")
+  expect(names).toContain("U4")
+})
+
+test("Arduino Nano has crystal oscillators Y1 and Y2", async () => {
+  const circuit = new Circuit()
+  circuit.add(<ArduinoNano />)
+  circuit.render()
+
+  const circuitJson = circuit.getCircuitJson()
+  const components = circuitJson.filter(
+    (item: any) => item.type === "source_component",
+  )
+
+  const names = components.map((c: any) => c.name)
+  expect(names).toContain("Y1")
+  expect(names).toContain("Y2")
+})

--- a/tests/test-arduino-nano.tsx
+++ b/tests/test-arduino-nano.tsx
@@ -36,8 +36,26 @@ const port = (soup: SoupElement[], componentName: string, label: string) => {
   return match!
 }
 
+const portByPinNumber = (
+  soup: SoupElement[],
+  componentName: string,
+  pinNumber: number,
+) => {
+  const match = portsFor(soup, componentName).find(
+    (sourcePort) => sourcePort.pin_number === pinNumber,
+  )
+  expect(match, `missing ${componentName} pin ${pinNumber}`).toBeDefined()
+  return match!
+}
+
 const netKey = (soup: SoupElement[], componentName: string, label: string) =>
   port(soup, componentName, label).subcircuit_connectivity_map_key
+
+const netKeyByPinNumber = (
+  soup: SoupElement[],
+  componentName: string,
+  pinNumber: number,
+) => portByPinNumber(soup, componentName, pinNumber).subcircuit_connectivity_map_key
 
 const expectSharedNet = (
   soup: SoupElement[],
@@ -60,39 +78,43 @@ const sourceNet = (soup: SoupElement[], name: string) => {
 test("Arduino Nano has correct board dimensions (45mm × 18mm)", () => {
   const soup = renderArduinoNano()
   const board = soup.find((element) => element.type === "pcb_board")
-
   expect(board?.width).toBe(45)
   expect(board?.height).toBe(18)
 })
 
 test("Arduino Nano has all major ICs and connectors", () => {
   const soup = renderArduinoNano()
-
   expect(byName(soup, "U1").manufacturer_part_number).toBe("ATmega328P-AU")
   expect(byName(soup, "U2").manufacturer_part_number).toBe("CH340G")
   expect(byName(soup, "U3").manufacturer_part_number).toBe("AMS1117-5.0")
   expect(byName(soup, "U4").manufacturer_part_number).toBe("AMS1117-3.3")
   expect(byName(soup, "J_USB").manufacturer_part_number).toBe("USB-MINI-B")
-
   for (const name of ["LED_PWR", "LED_TX", "LED_RX", "LED_L"]) {
     expect(byName(soup, name)).toBeDefined()
   }
 })
 
+test("Arduino Nano renders without source-level errors", () => {
+  const soup = renderArduinoNano()
+  const sourceIssues = soup.filter(
+    (element) =>
+      typeof element.type === "string" &&
+      element.type.startsWith("source_") &&
+      (element.type.endsWith("_error") || element.type.endsWith("_warning")),
+  )
+  expect(sourceIssues).toEqual([])
+})
+
 test("Arduino Nano has dual clock domains: 16MHz for MCU and 12MHz for CH340G", () => {
   const soup = renderArduinoNano()
-
   expect(byName(soup, "Y1").manufacturer_part_number).toBe("16MHz")
   expect(byName(soup, "Y2").manufacturer_part_number).toBe("12MHz")
-
   // 16MHz crystal wired to ATmega328P XTAL pins
   expectSharedNet(soup, ["U1", "XTAL1"], ["Y1", "XTAL1"])
   expectSharedNet(soup, ["U1", "XTAL2"], ["Y1", "XTAL2"])
-
   // 12MHz crystal wired to CH340G XI/XO pins
   expectSharedNet(soup, ["U2", "XI"], ["Y2", "XI"])
   expectSharedNet(soup, ["U2", "XO"], ["Y2", "XO"])
-
   // Load capacitors on both crystals
   expectSharedNet(soup, ["C1", "pin1"], ["Y1", "XTAL1"])
   expectSharedNet(soup, ["C2", "pin1"], ["Y1", "XTAL2"])
@@ -102,10 +124,8 @@ test("Arduino Nano has dual clock domains: 16MHz for MCU and 12MHz for CH340G", 
 
 test("Arduino Nano exposes standard dual 15-pin public header map (JP1 + JP2)", () => {
   const soup = renderArduinoNano()
-
   const jp1Labels = portsFor(soup, "JP1").map((p) => p.name)
   const jp2Labels = portsFor(soup, "JP2").map((p) => p.name)
-
   expect(jp1Labels).toEqual([
     "D1_TX",
     "D0_RX",
@@ -142,44 +162,97 @@ test("Arduino Nano exposes standard dual 15-pin public header map (JP1 + JP2)", 
   ])
 })
 
+test("Arduino Nano maps CH340G SOIC-16 pins to the correct physical nets", () => {
+  const soup = renderArduinoNano()
+  // CH340G SOIC-16 pinmap: [pinNumber, pinLabel, connectedComponent, connectedPin]
+  // pin1=TXD→U1.D0_RX, pin2=RXD→U1.D1_TX, pin3=V3→VCC3V3,
+  // pin4=UD_PLUS→J_USB.D_PLUS, pin5=UD_MINUS→J_USB.D_MINUS,
+  // pin6=XI→Y2.XI, pin7=XO→Y2.XO, pin8=TEST→GND,
+  // pin9=GND→GND, pin10-13=CTS/DSR/RI/DCD→GND, pin14=DTR→C_RESET.pin1,
+  // pin15=RTS→GND, pin16=VCC→VCC5
+  const expectedPinLabels: Array<[number, string]> = [
+    [1, "TXD"],
+    [2, "RXD"],
+    [3, "V3"],
+    [4, "UD_PLUS"],
+    [5, "UD_MINUS"],
+    [6, "XI"],
+    [7, "XO"],
+    [8, "TEST"],
+    [9, "GND"],
+    [10, "CTS"],
+    [11, "DSR"],
+    [12, "RI"],
+    [13, "DCD"],
+    [14, "DTR"],
+    [15, "RTS"],
+    [16, "VCC"],
+  ]
+  for (const [pinNumber, label] of expectedPinLabels) {
+    const sourcePort = portByPinNumber(soup, "U2", pinNumber)
+    expect(sourcePort.name, `U2 pin ${pinNumber} label`).toBe(label)
+  }
+  // Verify key net connections via pin number
+  expect(
+    netKeyByPinNumber(soup, "U2", 1),
+    "U2 pin1 TXD → U1.D0_RX",
+  ).toBe(netKey(soup, "U1", "D0_RX"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 2),
+    "U2 pin2 RXD → U1.D1_TX",
+  ).toBe(netKey(soup, "U1", "D1_TX"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 4),
+    "U2 pin4 UD_PLUS → J_USB.D_PLUS",
+  ).toBe(netKey(soup, "J_USB", "D_PLUS"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 5),
+    "U2 pin5 UD_MINUS → J_USB.D_MINUS",
+  ).toBe(netKey(soup, "J_USB", "D_MINUS"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 6),
+    "U2 pin6 XI → Y2.XI",
+  ).toBe(netKey(soup, "Y2", "XI"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 7),
+    "U2 pin7 XO → Y2.XO",
+  ).toBe(netKey(soup, "Y2", "XO"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 14),
+    "U2 pin14 DTR → C_RESET.pin1",
+  ).toBe(netKey(soup, "C_RESET", "pin1"))
+})
+
 test("Arduino Nano connects serial, reset, ICSP, analog, and power nets", () => {
   const soup = renderArduinoNano()
-
   // Serial: CH340G TXD -> MCU RX, CH340G RXD -> MCU TX
   expectSharedNet(soup, ["JP1", "D0_RX"], ["U1", "D0_RX"])
   expectSharedNet(soup, ["JP1", "D1_TX"], ["U1", "D1_TX"])
   expectSharedNet(soup, ["U2", "TXD"], ["U1", "D0_RX"])
   expectSharedNet(soup, ["U2", "RXD"], ["U1", "D1_TX"])
-
   // Auto-reset: CH340G DTR -> 100nF cap -> RESET
   expectSharedNet(soup, ["U2", "DTR"], ["C_RESET", "pin1"])
   expectSharedNet(soup, ["C_RESET", "pin2"], ["U1", "RESET"])
   expectSharedNet(soup, ["SW_RESET", "pin1"], ["U1", "RESET"])
-
   // ICSP header
   expectSharedNet(soup, ["ICSP", "MISO"], ["U1", "D12_MISO"])
   expectSharedNet(soup, ["ICSP", "MOSI"], ["U1", "D11_MOSI"])
   expectSharedNet(soup, ["ICSP", "SCK"], ["U1", "D13_SCK"])
   expectSharedNet(soup, ["ICSP", "RESET"], ["U1", "RESET"])
-
   // Analog pins
   expectSharedNet(soup, ["JP2", "A0"], ["U1", "A0"])
   expectSharedNet(soup, ["JP2", "A7"], ["U1", "A7"])
   expectSharedNet(soup, ["JP2", "AREF"], ["U1", "AREF"])
-
   // USB differential pair
   expectSharedNet(soup, ["J_USB", "D_PLUS"], ["U2", "UD_PLUS"])
   expectSharedNet(soup, ["J_USB", "D_MINUS"], ["U2", "UD_MINUS"])
-
   // Power rails present
   for (const netName of ["VIN", "VUSB", "VCC5", "VCC3V3", "GND"]) {
     sourceNet(soup, netName)
   }
-
   // Regulator outputs at headers
   expectSharedNet(soup, ["JP2", "5V"], ["U3", "OUT"])
   expectSharedNet(soup, ["JP2", "3V3"], ["U4", "OUT"])
-
-  // D13 LED
+  // D13 LED driven by ATmega D13_SCK via current-limiting resistor
   expectSharedNet(soup, ["R_LED_L", "pin1"], ["U1", "D13_SCK"])
 })


### PR DESCRIPTION
## Arduino Nano V3.0 — full tscircuit implementation

Implements the complete Arduino Nano V3.0 schematic as a tscircuit snippet (`snippets/arduino-nano.tsx`).

### Components

- MCU: ATmega328P-AU (TQFP-32, 32 pins fully mapped)
- USB-Serial: CH340G (SOIC-16, all 16 pins wired)
- 5V regulator: AMS1117-5.0 (SOT-223)
- 3.3V regulator: AMS1117-3.3 (SOT-223)
- 16MHz crystal (HC-49/S) + 22pF load caps for ATmega328P
- 12MHz crystal (HC-49/S) + 22pF load caps for CH340G
- Auto-reset: DTR → 100nF cap → RESET pin
- RESET pull-up: 10kΩ to VCC5 + pushbutton
- USB: Mini-B connector + SS14 Schottky diode (VUSB → VCC5)
- LEDs: Power/green, TX/orange, RX/orange, L\/D13\/yellow (all with 1kΩ resistors)
- Headers: JP1 15-pin digital, JP2 15-pin analog\/power, ICSP 2×3
- GND copper pours on top and bottom layers
- Board: 45mm × 18mm

### Verification

```
bun test tests/test-arduino-nano.tsx
```

7 tests, all pass:
- Arduino Nano has correct board dimensions (45mm × 18mm)
- Arduino Nano has all major ICs and connectors
- Arduino Nano renders without source-level errors
- Arduino Nano has dual clock domains: 16MHz for MCU and 12MHz for CH340G
- Arduino Nano exposes standard dual 15-pin public header map (JP1 + JP2)
- Arduino Nano maps CH340G SOIC-16 pins to the correct physical nets
- Arduino Nano connects serial, reset, ICSP, analog, and power nets

```
bunx tsc --noEmit  # passes
bun run build      # passes
git diff --check   # no whitespace errors
```

### Preview

https://tscircuit.com/editor

Paste the snippet from `snippets/arduino-nano.tsx` to render schematic + PCB layout.

Closes #328
/claim #328