### PR TITLE
feat: add Arduino Nano V3.0 tscircuit snippet (ATmega328P + CH340G)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Using tscircuit, you can design things like a <a target="_blank" href="https://b
 
 ## Example Circuits
 
+- [Arduino Nano V3.0](./snippets/arduino-nano.tsx) — Complete ATmega328P + CH340G design with dual crystals, regulators, ICSP, LEDs, and full 30-pin header breakout
 - [ESP32 Wifi Breakout Board](https://tscircuit.com/seveibar/wifi-test-board-1)
 
 ```tsx

--- a/snippets/arduino-nano.tsx
+++ b/snippets/arduino-nano.tsx
@@ -1,0 +1,669 @@
+import React from "react"
+
+const ATmega328P = (props: any) => (
+  <chip
+    manufacturerPartNumber="ATmega328P-AU"
+    footprint="tqfp32_p0.8mm"
+    pinLabels={{
+      pin1: "D3",
+      pin2: "D4",
+      pin3: "GND1",
+      pin4: "VCC1",
+      pin5: "GND2",
+      pin6: "VCC2",
+      pin7: "XTAL1",
+      pin8: "XTAL2",
+      pin9: "D5",
+      pin10: "D6",
+      pin11: "D7",
+      pin12: "D8",
+      pin13: "D9",
+      pin14: "D10_SS",
+      pin15: "D11_MOSI",
+      pin16: "D12_MISO",
+      pin17: "D13_SCK",
+      pin18: "AVCC",
+      pin19: "A6",
+      pin20: "AREF",
+      pin21: "GND3",
+      pin22: "A7",
+      pin23: "A0",
+      pin24: "A1",
+      pin25: "A2",
+      pin26: "A3",
+      pin27: "A4_SDA",
+      pin28: "A5_SCL",
+      pin29: "RESET",
+      pin30: "D0_RX",
+      pin31: "D1_TX",
+      pin32: "D2",
+    }}
+    schPinArrangement={{
+      leftSide: {
+        direction: "top-to-bottom",
+        pins: [
+          "pin30",
+          "pin31",
+          "pin32",
+          "pin1",
+          "pin2",
+          "pin9",
+          "pin10",
+          "pin11",
+          "pin12",
+          "pin13",
+          "pin14",
+          "pin15",
+          "pin16",
+          "pin17",
+          "pin29",
+        ],
+      },
+      rightSide: {
+        direction: "top-to-bottom",
+        pins: [
+          "pin23",
+          "pin24",
+          "pin25",
+          "pin26",
+          "pin27",
+          "pin28",
+          "pin19",
+          "pin22",
+          "pin20",
+          "pin18",
+          "pin7",
+          "pin8",
+        ],
+      },
+      topSide: {
+        direction: "left-to-right",
+        pins: ["pin4", "pin6"],
+      },
+      bottomSide: {
+        direction: "left-to-right",
+        pins: ["pin3", "pin5", "pin21"],
+      },
+    }}
+    {...props}
+  />
+)
+
+const CH340G = (props: any) => (
+  <chip
+    manufacturerPartNumber="CH340G"
+    footprint="soic16_w3.9mm_p1.27mm"
+    pinLabels={{
+      pin1: "GND",
+      pin2: "TXD",
+      pin3: "RXD",
+      pin4: "V3",
+      pin5: "UD_PLUS",
+      pin6: "UD_MINUS",
+      pin7: "XI",
+      pin8: "XO",
+      pin9: "CTS",
+      pin10: "DSR",
+      pin11: "RI",
+      pin12: "DCD",
+      pin13: "DTR",
+      pin14: "RTS",
+      pin15: "R232",
+      pin16: "VCC",
+    }}
+    schPinArrangement={{
+      leftSide: {
+        direction: "top-to-bottom",
+        pins: ["pin16", "pin4", "pin7", "pin8", "pin5", "pin6", "pin15", "pin1"],
+      },
+      rightSide: {
+        direction: "top-to-bottom",
+        pins: ["pin2", "pin3", "pin13", "pin14", "pin9", "pin10", "pin11", "pin12"],
+      },
+    }}
+    {...props}
+  />
+)
+
+const AMS1117 = (props: any) => (
+  <chip
+    footprint="sot223"
+    pinLabels={{
+      pin1: "GND",
+      pin2: "OUT",
+      pin3: "IN",
+      pin4: "OUT_TAB",
+    }}
+    {...props}
+  />
+)
+
+const ArduinoNanoComponent = () => (
+  <board width="45mm" height="18mm" autorouterEffortLevel="100x">
+    <copperpour
+      name="GND_TOP"
+      layer="top"
+      connectsTo="net.GND"
+      padMargin="0.25mm"
+      traceMargin="0.25mm"
+      boardEdgeMargin="0.4mm"
+    />
+    <copperpour
+      name="GND_BOTTOM"
+      layer="bottom"
+      connectsTo="net.GND"
+      padMargin="0.25mm"
+      traceMargin="0.25mm"
+      boardEdgeMargin="0.4mm"
+    />
+
+    <ATmega328P
+      name="U1"
+      schX={0}
+      schY={0}
+      pcbX={0}
+      pcbY={0}
+      connections={{
+        pin1: "net.D3",
+        pin2: "net.D4",
+        pin3: "net.GND",
+        pin4: "net.VCC5",
+        pin5: "net.GND",
+        pin6: "net.VCC5",
+        pin7: "net.XTAL16_1",
+        pin8: "net.XTAL16_2",
+        pin9: "net.D5",
+        pin10: "net.D6",
+        pin11: "net.D7",
+        pin12: "net.D8",
+        pin13: "net.D9",
+        pin14: "net.D10_SS",
+        pin15: "net.D11_MOSI",
+        pin16: "net.D12_MISO",
+        pin17: "net.D13_SCK",
+        pin18: "net.VCC5",
+        pin19: "net.A6",
+        pin20: "net.AREF",
+        pin21: "net.GND",
+        pin22: "net.A7",
+        pin23: "net.A0",
+        pin24: "net.A1",
+        pin25: "net.A2",
+        pin26: "net.A3",
+        pin27: "net.A4_SDA",
+        pin28: "net.A5_SCL",
+        pin29: "net.RESET",
+        pin30: "net.D0_RX",
+        pin31: "net.D1_TX",
+        pin32: "net.D2",
+      }}
+    />
+
+    <CH340G
+      name="U2"
+      schX={12}
+      schY={0}
+      pcbX={11}
+      pcbY={1.5}
+      connections={{
+        pin1: "net.GND",
+        pin2: "net.D0_RX",
+        pin3: "net.D1_TX",
+        pin4: "net.VCC3V3",
+        pin5: "net.USB_D_PLUS",
+        pin6: "net.USB_D_MINUS",
+        pin7: "net.XTAL12_1",
+        pin8: "net.XTAL12_2",
+        pin9: "net.GND",
+        pin10: "net.GND",
+        pin11: "net.GND",
+        pin12: "net.GND",
+        pin13: "net.DTR",
+        pin14: "net.RTS",
+        pin15: "net.GND",
+        pin16: "net.VCC5",
+      }}
+    />
+
+    <AMS1117
+      name="U3"
+      manufacturerPartNumber="AMS1117-5.0"
+      schX={13}
+      schY={-7}
+      pcbX={12}
+      pcbY={-5.5}
+      connections={{
+        pin1: "net.GND",
+        pin2: "net.VCC5",
+        pin3: "net.VIN",
+        pin4: "net.VCC5",
+      }}
+    />
+
+    <AMS1117
+      name="U4"
+      manufacturerPartNumber="AMS1117-3.3"
+      schX={13}
+      schY={-11}
+      pcbX={17}
+      pcbY={-5.5}
+      connections={{
+        pin1: "net.GND",
+        pin2: "net.VCC3V3",
+        pin3: "net.VCC5",
+        pin4: "net.VCC3V3",
+      }}
+    />
+
+    <chip
+      name="J_USB"
+      manufacturerPartNumber="USB-MINI-B"
+      footprint="pinrow5_p1mm_id0.7mm_od1mm"
+      pinLabels={{
+        pin1: "VBUS",
+        pin2: "D_MINUS",
+        pin3: "D_PLUS",
+        pin4: "ID",
+        pin5: "GND",
+      }}
+      schX={22}
+      schY={0}
+      pcbX={21}
+      pcbY={0}
+      connections={{
+        pin1: "net.VUSB",
+        pin2: "net.USB_D_MINUS",
+        pin3: "net.USB_D_PLUS",
+        pin5: "net.GND",
+      }}
+    />
+
+    <diode
+      name="D_USB"
+      manufacturerPartNumber="SS14"
+      footprint="sod123"
+      pcbX={17}
+      pcbY={-2.5}
+      connections={{ anode: "net.VUSB", cathode: "net.VCC5" }}
+    />
+
+    <crystal
+      name="Y1"
+      frequency="16MHz"
+      footprint="hc49"
+      loadCapacitance="22pF"
+      schX={-8}
+      schY={3}
+      pcbX={-15}
+      pcbY={1.8}
+      connections={{ pin1: "net.XTAL16_1", pin2: "net.XTAL16_2" }}
+    />
+    <capacitor
+      name="C1"
+      capacitance="22pF"
+      footprint="0402"
+      schX={-11}
+      schY={5}
+      pcbX={-18}
+      pcbY={2.8}
+      connections={{ pin1: "net.XTAL16_1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C2"
+      capacitance="22pF"
+      footprint="0402"
+      schX={-11}
+      schY={7}
+      pcbX={-18}
+      pcbY={1.2}
+      connections={{ pin1: "net.XTAL16_2", pin2: "net.GND" }}
+    />
+
+    <crystal
+      name="Y2"
+      frequency="12MHz"
+      footprint="hc49"
+      loadCapacitance="22pF"
+      schX={16}
+      schY={4}
+      pcbX={12.5}
+      pcbY={5.4}
+      connections={{ pin1: "net.XTAL12_1", pin2: "net.XTAL12_2" }}
+    />
+    <capacitor
+      name="C3"
+      capacitance="22pF"
+      footprint="0402"
+      schX={19}
+      schY={5}
+      pcbX={14.5}
+      pcbY={5}
+      connections={{ pin1: "net.XTAL12_1", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C4"
+      capacitance="22pF"
+      footprint="0402"
+      schX={19}
+      schY={7}
+      pcbX={14.5}
+      pcbY={6}
+      connections={{ pin1: "net.XTAL12_2", pin2: "net.GND" }}
+    />
+
+    <capacitor
+      name="C_RESET"
+      capacitance="100nF"
+      footprint="0402"
+      schX={7}
+      schY={-5}
+      pcbX={-10}
+      pcbY={-2.2}
+      connections={{ pin1: "net.DTR", pin2: "net.RESET" }}
+    />
+
+    <resistor
+      name="R_RESET"
+      resistance="10kohm"
+      footprint="0402"
+      schX={4}
+      schY={-5}
+      pcbX={-10}
+      pcbY={-4.2}
+      connections={{ pin1: "net.VCC5", pin2: "net.RESET" }}
+    />
+
+    <pushbutton
+      name="SW_RESET"
+      footprint="pushbutton_smd_4mm"
+      pinLabels={{
+        pin1: "RESET_A",
+        pin2: "GND_A",
+        pin3: "RESET_B",
+        pin4: "GND_B",
+      }}
+      schX={4}
+      schY={-8}
+      pcbX={-13}
+      pcbY={-2.5}
+      connections={{
+        pin1: "net.RESET",
+        pin2: "net.GND",
+        pin3: "net.RESET",
+        pin4: "net.GND",
+      }}
+    />
+
+    <pinheader
+      name="ICSP"
+      pinCount={6}
+      doubleRow
+      footprint="pinrow6_rows2_p2.54mm_id1mm_od1.5mm_male"
+      pinLabels={{
+        pin1: "MISO",
+        pin2: "5V",
+        pin3: "SCK",
+        pin4: "MOSI",
+        pin5: "RESET",
+        pin6: "GND",
+      }}
+      schX={-10}
+      schY={-7}
+      pcbX={-13}
+      pcbY={2.8}
+      connections={{
+        pin1: "net.D12_MISO",
+        pin2: "net.VCC5",
+        pin3: "net.D13_SCK",
+        pin4: "net.D11_MOSI",
+        pin5: "net.RESET",
+        pin6: "net.GND",
+      }}
+    />
+
+    <pinheader
+      name="JP1"
+      pinCount={15}
+      footprint="pinrow15_p2.54mm_id1mm_od1.5mm_male"
+      pinLabels={{
+        pin1: "D1_TX",
+        pin2: "D0_RX",
+        pin3: "RESET",
+        pin4: "GND",
+        pin5: "D2",
+        pin6: "D3",
+        pin7: "D4",
+        pin8: "D5",
+        pin9: "D6",
+        pin10: "D7",
+        pin11: "D8",
+        pin12: "D9",
+        pin13: "D10_SS",
+        pin14: "D11_MOSI",
+        pin15: "D12_MISO",
+      }}
+      schX={-17}
+      schY={0}
+      pcbX={0}
+      pcbY={-8}
+      connections={{
+        pin1: "net.D1_TX",
+        pin2: "net.D0_RX",
+        pin3: "net.RESET",
+        pin4: "net.GND",
+        pin5: "net.D2",
+        pin6: "net.D3",
+        pin7: "net.D4",
+        pin8: "net.D5",
+        pin9: "net.D6",
+        pin10: "net.D7",
+        pin11: "net.D8",
+        pin12: "net.D9",
+        pin13: "net.D10_SS",
+        pin14: "net.D11_MOSI",
+        pin15: "net.D12_MISO",
+      }}
+    />
+
+    <pinheader
+      name="JP2"
+      pinCount={15}
+      footprint="pinrow15_p2.54mm_id1mm_od1.5mm_male"
+      pinLabels={{
+        pin1: "VIN",
+        pin2: "GND",
+        pin3: "RESET",
+        pin4: "5V",
+        pin5: "A7",
+        pin6: "A6",
+        pin7: "A5_SCL",
+        pin8: "A4_SDA",
+        pin9: "A3",
+        pin10: "A2",
+        pin11: "A1",
+        pin12: "A0",
+        pin13: "AREF",
+        pin14: "3V3",
+        pin15: "D13_SCK",
+      }}
+      schX={17}
+      schY={0}
+      pcbX={0}
+      pcbY={8}
+      connections={{
+        pin1: "net.VIN",
+        pin2: "net.GND",
+        pin3: "net.RESET",
+        pin4: "net.VCC5",
+        pin5: "net.A7",
+        pin6: "net.A6",
+        pin7: "net.A5_SCL",
+        pin8: "net.A4_SDA",
+        pin9: "net.A3",
+        pin10: "net.A2",
+        pin11: "net.A1",
+        pin12: "net.A0",
+        pin13: "net.AREF",
+        pin14: "net.VCC3V3",
+        pin15: "net.D13_SCK",
+      }}
+    />
+
+    <resistor
+      name="R_LED_PWR"
+      resistance="1kohm"
+      footprint="0402"
+      schX={4}
+      schY={-12}
+      pcbX={-6}
+      pcbY={-7}
+      connections={{ pin1: "net.VCC5", pin2: "net.LED_PWR_A" }}
+    />
+    <led
+      name="LED_PWR"
+      color="green"
+      footprint="0402"
+      schX={7}
+      schY={-12}
+      pcbX={-5}
+      pcbY={-7}
+      connections={{ anode: "net.LED_PWR_A", cathode: "net.GND" }}
+    />
+
+    <resistor
+      name="R_LED_TX"
+      resistance="1kohm"
+      footprint="0402"
+      schX={10}
+      schY={-12}
+      pcbX={-2}
+      pcbY={-7}
+      connections={{ pin1: "net.D1_TX", pin2: "net.LED_TX_A" }}
+    />
+    <led
+      name="LED_TX"
+      color="orange"
+      footprint="0402"
+      schX={13}
+      schY={-12}
+      pcbX={-1}
+      pcbY={-7}
+      connections={{ anode: "net.LED_TX_A", cathode: "net.GND" }}
+    />
+
+    <resistor
+      name="R_LED_RX"
+      resistance="1kohm"
+      footprint="0402"
+      schX={16}
+      schY={-12}
+      pcbX={2}
+      pcbY={-7}
+      connections={{ pin1: "net.D0_RX", pin2: "net.LED_RX_A" }}
+    />
+    <led
+      name="LED_RX"
+      color="orange"
+      footprint="0402"
+      schX={19}
+      schY={-12}
+      pcbX={3}
+      pcbY={-7}
+      connections={{ anode: "net.LED_RX_A", cathode: "net.GND" }}
+    />
+
+    <resistor
+      name="R_LED_L"
+      resistance="1kohm"
+      footprint="0402"
+      schX={22}
+      schY={-12}
+      pcbX={6}
+      pcbY={-7}
+      connections={{ pin1: "net.D13_SCK", pin2: "net.LED_L_A" }}
+    />
+    <led
+      name="LED_L"
+      color="yellow"
+      footprint="0402"
+      schX={25}
+      schY={-12}
+      pcbX={7}
+      pcbY={-7}
+      connections={{ anode: "net.LED_L_A", cathode: "net.GND" }}
+    />
+
+    <capacitor
+      name="C_AREF"
+      capacitance="100nF"
+      footprint="0402"
+      schX={-5}
+      schY={7}
+      pcbX={-8}
+      pcbY={3.8}
+      connections={{ pin1: "net.AREF", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_VCC1"
+      capacitance="100nF"
+      footprint="0402"
+      schX={-2}
+      schY={7}
+      pcbX={-8}
+      pcbY={2.6}
+      connections={{ pin1: "net.VCC5", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_AVCC"
+      capacitance="100nF"
+      footprint="0402"
+      schX={1}
+      schY={7}
+      pcbX={-8}
+      pcbY={1.4}
+      connections={{ pin1: "net.VCC5", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_USB"
+      capacitance="100nF"
+      footprint="0402"
+      schX={22}
+      schY={3}
+      pcbX={18}
+      pcbY={3.5}
+      connections={{ pin1: "net.VUSB", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_VIN_BULK"
+      capacitance="10uF"
+      footprint="0805"
+      schX={16}
+      schY={-7}
+      pcbX={14}
+      pcbY={-4.5}
+      connections={{ pin1: "net.VIN", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_5V_OUT"
+      capacitance="10uF"
+      footprint="0805"
+      schX={16}
+      schY={-9}
+      pcbX={14}
+      pcbY={-6.5}
+      connections={{ pin1: "net.VCC5", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C_3V3_OUT"
+      capacitance="10uF"
+      footprint="0805"
+      schX={16}
+      schY={-11}
+      pcbX={19}
+      pcbY={-6.5}
+      connections={{ pin1: "net.VCC3V3", pin2: "net.GND" }}
+    />
+  </board>
+)
+
+export default ArduinoNanoComponent

--- a/tests/arduino-nano.test.tsx
+++ b/tests/arduino-nano.test.tsx
@@ -1,0 +1,240 @@
+import { expect, test } from "bun:test"
+import { Circuit } from "../dist"
+import ArduinoNanoComponent from "../snippets/arduino-nano"
+
+type SoupElement = Record<string, any>
+
+const renderArduinoNano = () => {
+  const circuit = new Circuit()
+  circuit.add(<ArduinoNanoComponent />)
+  circuit.render()
+  return circuit.getCircuitJson() as SoupElement[]
+}
+
+const byName = (soup: SoupElement[], name: string) => {
+  const component = soup.find(
+    (element) => element.type === "source_component" && element.name === name,
+  )
+  expect(component, `missing source component ${name}`).toBeDefined()
+  return component!
+}
+
+const portsFor = (soup: SoupElement[], componentName: string) => {
+  const component = byName(soup, componentName)
+  return soup.filter(
+    (element) =>
+      element.type === "source_port" &&
+      element.source_component_id === component.source_component_id,
+  )
+}
+
+const port = (soup: SoupElement[], componentName: string, label: string) => {
+  const match = portsFor(soup, componentName).find((sourcePort) =>
+    sourcePort.port_hints?.includes(label),
+  )
+  expect(match, `missing ${componentName}.${label}`).toBeDefined()
+  return match!
+}
+
+const portByPinNumber = (
+  soup: SoupElement[],
+  componentName: string,
+  pinNumber: number,
+) => {
+  const match = portsFor(soup, componentName).find(
+    (sourcePort) => sourcePort.pin_number === pinNumber,
+  )
+  expect(match, `missing ${componentName} pin ${pinNumber}`).toBeDefined()
+  return match!
+}
+
+const netKey = (soup: SoupElement[], componentName: string, label: string) =>
+  port(soup, componentName, label).subcircuit_connectivity_map_key
+
+const netKeyByPinNumber = (
+  soup: SoupElement[],
+  componentName: string,
+  pinNumber: number,
+) => portByPinNumber(soup, componentName, pinNumber).subcircuit_connectivity_map_key
+
+const expectSharedNet = (
+  soup: SoupElement[],
+  left: [string, string],
+  right: [string, string],
+) => {
+  expect(netKey(soup, ...left), `${left.join(".")} net`).toBe(
+    netKey(soup, ...right),
+  )
+}
+
+const sourceNet = (soup: SoupElement[], name: string) => {
+  const net = soup.find(
+    (element) => element.type === "source_net" && element.name === name,
+  )
+  expect(net, `missing source net ${name}`).toBeDefined()
+  return net!
+}
+
+test("Arduino Nano has correct board dimensions (45mm × 18mm)", () => {
+  const soup = renderArduinoNano()
+  const board = soup.find((element) => element.type === "pcb_board")
+  expect(board?.width).toBe(45)
+  expect(board?.height).toBe(18)
+})
+
+test("Arduino Nano has all major ICs and connectors", () => {
+  const soup = renderArduinoNano()
+  expect(byName(soup, "U1").manufacturer_part_number).toBe("ATmega328P-AU")
+  expect(byName(soup, "U2").manufacturer_part_number).toBe("CH340G")
+  expect(byName(soup, "U3").manufacturer_part_number).toBe("AMS1117-5.0")
+  expect(byName(soup, "U4").manufacturer_part_number).toBe("AMS1117-3.3")
+  expect(byName(soup, "J_USB").manufacturer_part_number).toBe("USB-MINI-B")
+  for (const name of ["LED_PWR", "LED_TX", "LED_RX", "LED_L"]) {
+    expect(byName(soup, name)).toBeDefined()
+  }
+})
+
+test("Arduino Nano renders without source-level errors", () => {
+  const soup = renderArduinoNano()
+  const sourceIssues = soup.filter(
+    (element) =>
+      typeof element.type === "string" &&
+      element.type.startsWith("source_") &&
+      (element.type.endsWith("_error") || element.type.endsWith("_warning")),
+  )
+  expect(sourceIssues).toEqual([])
+})
+
+test("Arduino Nano has dual clock domains: 16MHz for MCU and 12MHz for CH340G", () => {
+  const soup = renderArduinoNano()
+  expect(byName(soup, "Y1").frequency).toBe(16000000)
+  expect(byName(soup, "Y2").frequency).toBe(12000000)
+  expectSharedNet(soup, ["U1", "XTAL1"], ["Y1", "pin1"])
+  expectSharedNet(soup, ["U1", "XTAL2"], ["Y1", "pin2"])
+  expectSharedNet(soup, ["U2", "XI"], ["Y2", "pin1"])
+  expectSharedNet(soup, ["U2", "XO"], ["Y2", "pin2"])
+  expectSharedNet(soup, ["C1", "pin1"], ["Y1", "pin1"])
+  expectSharedNet(soup, ["C2", "pin1"], ["Y1", "pin2"])
+  expectSharedNet(soup, ["C3", "pin1"], ["Y2", "pin1"])
+  expectSharedNet(soup, ["C4", "pin1"], ["Y2", "pin2"])
+})
+
+test("Arduino Nano exposes standard dual 15-pin public header map (JP1 + JP2)", () => {
+  const soup = renderArduinoNano()
+  const jp1Labels = portsFor(soup, "JP1").map((p) => p.name)
+  const jp2Labels = portsFor(soup, "JP2").map((p) => p.name)
+  expect(jp1Labels).toEqual([
+    "D1_TX",
+    "D0_RX",
+    "RESET",
+    "GND",
+    "D2",
+    "D3",
+    "D4",
+    "D5",
+    "D6",
+    "D7",
+    "D8",
+    "D9",
+    "D10_SS",
+    "D11_MOSI",
+    "D12_MISO",
+  ])
+  expect(jp2Labels).toEqual([
+    "VIN",
+    "GND",
+    "RESET",
+    "5V",
+    "A7",
+    "A6",
+    "A5_SCL",
+    "A4_SDA",
+    "A3",
+    "A2",
+    "A1",
+    "A0",
+    "AREF",
+    "3V3",
+    "D13_SCK",
+  ])
+})
+
+test("Arduino Nano maps CH340G SOIC-16 pins to the correct physical nets", () => {
+  const soup = renderArduinoNano()
+  const expectedPinLabels: Array<[number, string]> = [
+    [1, "GND"],
+    [2, "TXD"],
+    [3, "RXD"],
+    [4, "V3"],
+    [5, "UD_PLUS"],
+    [6, "UD_MINUS"],
+    [7, "XI"],
+    [8, "XO"],
+    [9, "CTS"],
+    [10, "DSR"],
+    [11, "RI"],
+    [12, "DCD"],
+    [13, "DTR"],
+    [14, "RTS"],
+    [15, "R232"],
+    [16, "VCC"],
+  ]
+  for (const [pinNumber, label] of expectedPinLabels) {
+    const sourcePort = portByPinNumber(soup, "U2", pinNumber)
+    expect(sourcePort.name, `U2 pin ${pinNumber} label`).toBe(label)
+  }
+  expect(
+    netKeyByPinNumber(soup, "U2", 2),
+    "U2 pin2 TXD → U1.D0_RX",
+  ).toBe(netKey(soup, "U1", "D0_RX"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 3),
+    "U2 pin3 RXD → U1.D1_TX",
+  ).toBe(netKey(soup, "U1", "D1_TX"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 5),
+    "U2 pin5 UD_PLUS → J_USB.D_PLUS",
+  ).toBe(netKey(soup, "J_USB", "D_PLUS"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 6),
+    "U2 pin6 UD_MINUS → J_USB.D_MINUS",
+  ).toBe(netKey(soup, "J_USB", "D_MINUS"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 7),
+    "U2 pin7 XI → Y2.pin1",
+  ).toBe(netKey(soup, "Y2", "pin1"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 8),
+    "U2 pin8 XO → Y2.pin2",
+  ).toBe(netKey(soup, "Y2", "pin2"))
+  expect(
+    netKeyByPinNumber(soup, "U2", 13),
+    "U2 pin13 DTR → C_RESET.pin1",
+  ).toBe(netKey(soup, "C_RESET", "pin1"))
+})
+
+test("Arduino Nano connects serial, reset, ICSP, analog, and power nets", () => {
+  const soup = renderArduinoNano()
+  expectSharedNet(soup, ["JP1", "D0_RX"], ["U1", "D0_RX"])
+  expectSharedNet(soup, ["JP1", "D1_TX"], ["U1", "D1_TX"])
+  expectSharedNet(soup, ["U2", "TXD"], ["U1", "D0_RX"])
+  expectSharedNet(soup, ["U2", "RXD"], ["U1", "D1_TX"])
+  expectSharedNet(soup, ["U2", "DTR"], ["C_RESET", "pin1"])
+  expectSharedNet(soup, ["C_RESET", "pin2"], ["U1", "RESET"])
+  expectSharedNet(soup, ["SW_RESET", "RESET_A"], ["U1", "RESET"])
+  expectSharedNet(soup, ["ICSP", "MISO"], ["U1", "D12_MISO"])
+  expectSharedNet(soup, ["ICSP", "MOSI"], ["U1", "D11_MOSI"])
+  expectSharedNet(soup, ["ICSP", "SCK"], ["U1", "D13_SCK"])
+  expectSharedNet(soup, ["ICSP", "RESET"], ["U1", "RESET"])
+  expectSharedNet(soup, ["JP2", "A0"], ["U1", "A0"])
+  expectSharedNet(soup, ["JP2", "A7"], ["U1", "A7"])
+  expectSharedNet(soup, ["JP2", "AREF"], ["U1", "AREF"])
+  expectSharedNet(soup, ["J_USB", "D_PLUS"], ["U2", "UD_PLUS"])
+  expectSharedNet(soup, ["J_USB", "D_MINUS"], ["U2", "UD_MINUS"])
+  for (const netName of ["VIN", "VUSB", "VCC5", "VCC3V3", "GND"]) {
+    sourceNet(soup, netName)
+  }
+  expectSharedNet(soup, ["JP2", "5V"], ["U3", "OUT"])
+  expectSharedNet(soup, ["JP2", "3V3"], ["U4", "OUT"])
+  expectSharedNet(soup, ["R_LED_L", "pin1"], ["U1", "D13_SCK"])
+})


### PR DESCRIPTION
## Arduino Nano V3.0 — full tscircuit implementation

Implements the complete Arduino Nano V3.0 schematic as a tscircuit snippet (`snippets/arduino-nano.tsx`).

### Components
- MCU: ATmega328P-AU (TQFP-32, all 32 pins fully mapped)
- USB-Serial: CH340G (SOIC-16, correct pinout per WCH datasheet: pin1=GND)
- 5V regulator: AMS1117-5.0 (SOT-223)
- 3.3V regulator: AMS1117-3.3 (SOT-223)
- 16MHz crystal (HC-49/S) + 22pF load caps for ATmega328P
- 12MHz crystal (HC-49/S) + 22pF load caps for CH340G
- Auto-reset: DTR → 100nF cap → RESET pin
- RESET pull-up: 10kΩ to VCC5 + pushbutton
- USB: Mini-B connector + SS14 Schottky diode (VUSB → VCC5)
- LEDs: Power/green, TX/orange, RX/orange, L/D13/yellow (all with 1kΩ resistors)
- Headers: JP1 15-pin digital, JP2 15-pin analog/power, ICSP 2×3
- GND copper pours on top and bottom layers
- Board: 45mm × 18mm

### Verification
```
bun test tests/arduino-nano.test.tsx
```
7 tests, all pass:
- Arduino Nano has correct board dimensions (45mm × 18mm)
- Arduino Nano has all major ICs and connectors
- Arduino Nano renders without source-level errors
- Arduino Nano has dual clock domains: 16MHz for MCU and 12MHz for CH340G
- Arduino Nano exposes standard dual 15-pin public header map (JP1 + JP2)
- Arduino Nano maps CH340G SOIC-16 pins to the correct physical nets
- Arduino Nano connects serial, reset, ICSP, analog, and power nets

```
bun test # 9 pass, 0 fail
```

/claim #328