### PR TITLE
Add Arduino Nano V3.0 example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Using tscircuit, you can design things like a <a target="_blank" href="https://b
 ## Example Circuits
 
 - [ESP32 Wifi Breakout Board](https://tscircuit.com/seveibar/wifi-test-board-1)
+- [Arduino Nano V3.0](https://github.com/sourcesss/arduino-nano-v3-tscircuit)
 
 ```tsx
 const Circuit = () => (


### PR DESCRIPTION
Closes #328

/claim #328

## Summary
- Adds an Arduino Nano V3.0 example link to the README example circuits list.
- The linked project models the Nano form factor with ATmega328P-AU, CH340G USB-UART, USB Mini-B, VIN/5V/3V3 rails, ICSP, reset, crystals, Nano headers, and status LEDs.

Project: https://github.com/sourcesss/arduino-nano-v3-tscircuit

## Proof
- `bun test` in the linked project: 1 passing smoke test rendering the board through `tscircuit`.
- `git diff --check` in this repository: clean.
