### PR TITLE
feat: add Arduino Nano V3.0 example circuit design (#328)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Using tscircuit, you can design things like a <a target="_blank" href="https://b
 ## Example Circuits
 
 - [ESP32 Wifi Breakout Board](https://tscircuit.com/seveibar/wifi-test-board-1)
+- [Arduino Nano V3 (ATmega328P + CH340G)](https://github.com/tscircuit/tscircuit/tree/main/examples/arduino-nano)
 
 ```tsx
 const Circuit = () => (

--- a/examples/arduino-nano/ArduinoNanoV3.tsx
+++ b/examples/arduino-nano/ArduinoNanoV3.tsx
@@ -1,0 +1,194 @@
+import React from "react"
+import { ATmega328PCore } from "./components/ATmega328PCore"
+import { CH340GSerial } from "./components/CH340GSerial"
+
+export const ArduinoNanoV3 = () => (
+  <board width="18mm" height="45mm">
+    {/* === Core Modules === */}
+    <ATmega328PCore name="MCU" />
+    <CH340GSerial name="SERIAL" />
+
+    {/* === Power Supply Section === */}
+
+    {/* AMS1117-5.0 Voltage Regulator (SOT-223) */}
+    <chip name="U3" footprint="sot223"
+      pinLabels={{ pin1: "GND", pin2: "VOUT", pin3: "VIN", pin4: "VOUT2" }}
+      pcbX="0mm" pcbY="-20mm"
+    />
+
+    {/* Schottky Diode — protects against reverse USB power */}
+    <diode name="D1" footprint="sod123" pcbX="3mm" pcbY="-20mm" />
+
+    {/* PTC Resettable Fuse — 500mA overcurrent protection */}
+    <chip name="F1" footprint="1206"
+      pinLabels={{ pin1: "IN", pin2: "OUT" }}
+      pcbX="-3mm" pcbY="-20mm"
+    />
+
+    {/* Regulator input capacitor — 10µF smooths input voltage */}
+    <capacitor name="C_REG_IN" capacitance="10uF" footprint="0805"
+      pcbX="-2mm" pcbY="-22mm" />
+
+    {/* Regulator output capacitor — 10µF stabilizes 5V output */}
+    <capacitor name="C_REG_OUT" capacitance="10uF" footprint="0805"
+      pcbX="2mm" pcbY="-22mm" />
+
+    {/* Power LED (green) — shows board is powered */}
+    <led name="LED_PWR" footprint="0805" pcbX="5mm" pcbY="-20mm" />
+    <resistor name="R_PWR" resistance="1kohm" footprint="0805"
+      pcbX="7mm" pcbY="-20mm" />
+
+    {/* === Reset Switch === */}
+    <chip name="SW1" footprint="tactile_switch_6x6mm"
+      pinLabels={{ pin1: "A", pin2: "B" }}
+      pcbX="-6mm" pcbY="5mm"
+    />
+
+    {/* === Pin Headers === */}
+
+    {/* Left header — 15 pins */}
+    <chip name="J1" footprint="pinrow15"
+      pinLabels={{
+        pin1: "D13", pin2: "3V3", pin3: "AREF",
+        pin4: "A0", pin5: "A1", pin6: "A2", pin7: "A3",
+        pin8: "A4", pin9: "A5", pin10: "A6", pin11: "A7",
+        pin12: "5V", pin13: "RST", pin14: "GND", pin15: "VIN"
+      }}
+      pcbX="-9mm" pcbY="0mm"
+    />
+
+    {/* Right header — 15 pins */}
+    <chip name="J2" footprint="pinrow15"
+      pinLabels={{
+        pin1: "D12", pin2: "D11", pin3: "D10", pin4: "D9",
+        pin5: "D8", pin6: "D7", pin7: "D6", pin8: "D5",
+        pin9: "D4", pin10: "D3", pin11: "D2", pin12: "GND2",
+        pin13: "RST2", pin14: "RX", pin15: "TX"
+      }}
+      pcbX="9mm" pcbY="0mm"
+    />
+
+    {/* ICSP Header — 2x3 pins for in-circuit programming */}
+    <chip name="J3" footprint="pinrow6"
+      pinLabels={{
+        pin1: "MISO", pin2: "VCC", pin3: "SCK",
+        pin4: "MOSI", pin5: "RESET", pin6: "GND"
+      }}
+      pcbX="0mm" pcbY="8mm"
+    />
+
+    {/* ========================================= */}
+    {/* ===  POWER SUPPLY TRACES  === */}
+    {/* ========================================= */}
+
+    {/* USB VBUS → Fuse → Diode → Regulator VIN */}
+    <trace path={[".SERIAL .USB1 > .VBUS", ".F1 > .IN"]} />
+    <trace path={[".F1 > .OUT", ".D1 > .anode"]} />
+    <trace path={[".D1 > .cathode", ".U3 > .VIN"]} />
+
+    {/* Regulator input capacitor */}
+    <trace path={[".C_REG_IN > .pos", ".U3 > .VIN"]} />
+    <trace path={[".C_REG_IN > .neg", ".U3 > .GND"]} />
+
+    {/* Regulator output capacitor */}
+    <trace path={[".C_REG_OUT > .pos", ".U3 > .VOUT"]} />
+    <trace path={[".C_REG_OUT > .neg", ".U3 > .GND"]} />
+
+    {/* Power LED: 5V → resistor → LED anode, LED cathode → GND */}
+    <trace path={[".U3 > .VOUT", ".R_PWR > .left"]} />
+    <trace path={[".R_PWR > .right", ".LED_PWR > .anode"]} />
+    <trace path={[".LED_PWR > .cathode", ".U3 > .GND"]} />
+
+    {/* ========================================= */}
+    {/* ===  POWER → MCU TRACES  === */}
+    {/* ========================================= */}
+
+    {/* 5V rail to MCU VCC and AVCC */}
+    <trace path={[".U3 > .VOUT", ".MCU .U1 > .VCC"]} />
+    <trace path={[".U3 > .VOUT", ".MCU .U1 > .AVCC"]} />
+
+    {/* GND from regulator to MCU GND */}
+    <trace path={[".U3 > .GND", ".MCU .U1 > .GND"]} />
+
+    {/* ========================================= */}
+    {/* ===  SERIAL ↔ MCU TRACES  === */}
+    {/* ========================================= */}
+
+    {/* CH340G TXD → ATmega328P RXD (D0) */}
+    <trace path={[".SERIAL .U2 > .TXD", ".MCU .U1 > .PD0_RXD"]} />
+
+    {/* CH340G RXD → ATmega328P TXD (D1) */}
+    <trace path={[".SERIAL .U2 > .RXD", ".MCU .U1 > .PD1_TXD"]} />
+
+    {/* ========================================= */}
+    {/* ===  AUTO-RESET TRACES  === */}
+    {/* ========================================= */}
+
+    {/* CH340G DTR → 100nF capacitor → MCU RESET */}
+    <trace path={[".SERIAL .U2 > .DTR", ".SERIAL .C_RST > .pos"]} />
+    <trace path={[".SERIAL .C_RST > .neg", ".MCU .U1 > .PC6_RESET"]} />
+
+    {/* Reset Switch: pin A → MCU RESET, pin B → GND */}
+    <trace path={[".SW1 > .A", ".MCU .U1 > .PC6_RESET"]} />
+    <trace path={[".SW1 > .B", ".MCU .U1 > .GND"]} />
+
+    {/* ========================================= */}
+    {/* ===  HEADER → MCU DIGITAL PINS  === */}
+    {/* ========================================= */}
+
+    <trace path={[".J1 > .D13", ".MCU .U1 > .PB5_SCK"]} />
+    <trace path={[".J2 > .D12", ".MCU .U1 > .PB4_MISO"]} />
+    <trace path={[".J2 > .D11", ".MCU .U1 > .PB3_MOSI"]} />
+    <trace path={[".J2 > .D10", ".MCU .U1 > .PB2"]} />
+    <trace path={[".J2 > .D9", ".MCU .U1 > .PB1"]} />
+    <trace path={[".J2 > .D8", ".MCU .U1 > .PB0"]} />
+    <trace path={[".J2 > .D7", ".MCU .U1 > .PD7"]} />
+    <trace path={[".J2 > .D6", ".MCU .U1 > .PD6"]} />
+    <trace path={[".J2 > .D5", ".MCU .U1 > .PD5"]} />
+    <trace path={[".J2 > .D4", ".MCU .U1 > .PD4"]} />
+    <trace path={[".J2 > .D3", ".MCU .U1 > .PD3"]} />
+    <trace path={[".J2 > .D2", ".MCU .U1 > .PD2"]} />
+    <trace path={[".J2 > .TX", ".MCU .U1 > .PD1_TXD"]} />
+    <trace path={[".J2 > .RX", ".MCU .U1 > .PD0_RXD"]} />
+
+    {/* ========================================= */}
+    {/* ===  HEADER → MCU ANALOG PINS  === */}
+    {/* ========================================= */}
+
+    <trace path={[".J1 > .A0", ".MCU .U1 > .PC0"]} />
+    <trace path={[".J1 > .A1", ".MCU .U1 > .PC1"]} />
+    <trace path={[".J1 > .A2", ".MCU .U1 > .PC2"]} />
+    <trace path={[".J1 > .A3", ".MCU .U1 > .PC3"]} />
+    <trace path={[".J1 > .A4", ".MCU .U1 > .PC4_SDA"]} />
+    <trace path={[".J1 > .A5", ".MCU .U1 > .PC5_SCL"]} />
+    <trace path={[".J1 > .A6", ".MCU .U1 > .ADC6"]} />
+    <trace path={[".J1 > .A7", ".MCU .U1 > .ADC7"]} />
+
+    {/* ========================================= */}
+    {/* ===  HEADER → POWER RAILS  === */}
+    {/* ========================================= */}
+
+    <trace path={[".J1 > .5V", ".U3 > .VOUT"]} />
+    <trace path={[".J1 > .GND", ".MCU .U1 > .GND"]} />
+    <trace path={[".J1 > .VIN", ".U3 > .VIN"]} />
+    <trace path={[".J1 > .RST", ".MCU .U1 > .PC6_RESET"]} />
+    <trace path={[".J1 > .AREF", ".MCU .U1 > .AREF"]} />
+    <trace path={[".J2 > .GND2", ".MCU .U1 > .GND"]} />
+
+    {/* 3V3 from CH340G V3 pin */}
+    <trace path={[".J1 > .3V3", ".SERIAL .U2 > .V3"]} />
+
+    {/* ========================================= */}
+    {/* ===  ICSP HEADER → MCU  === */}
+    {/* ========================================= */}
+
+    <trace path={[".J3 > .MISO", ".MCU .U1 > .PB4_MISO"]} />
+    <trace path={[".J3 > .MOSI", ".MCU .U1 > .PB3_MOSI"]} />
+    <trace path={[".J3 > .SCK", ".MCU .U1 > .PB5_SCK"]} />
+    <trace path={[".J3 > .RESET", ".MCU .U1 > .PC6_RESET"]} />
+    <trace path={[".J3 > .VCC", ".U3 > .VOUT"]} />
+    <trace path={[".J3 > .GND", ".MCU .U1 > .GND"]} />
+  </board>
+)
+
+export default ArduinoNanoV3

--- a/examples/arduino-nano/components/ATmega328PCore.tsx
+++ b/examples/arduino-nano/components/ATmega328PCore.tsx
@@ -1,0 +1,92 @@
+import React from "react"
+
+export const ATmega328PCore = ({ name }: { name: string }) => (
+  <group name={name}>
+    {/* ATmega328P-AU (TQFP-32) — the brain of the Arduino Nano */}
+    <chip
+      name="U1"
+      footprint="tqfp32_w7_h7_p0.8mm"
+      pinLabels={{
+        pin1: "PD3", pin2: "PD4",
+        pin3: "GND", pin4: "VCC", pin5: "GND2", pin6: "VCC2",
+        pin7: "XTAL1", pin8: "XTAL2",
+        pin9: "PD5", pin10: "PD6", pin11: "PD7",
+        pin12: "PB0", pin13: "PB1", pin14: "PB2",
+        pin15: "PB3_MOSI", pin16: "PB4_MISO", pin17: "PB5_SCK",
+        pin18: "AVCC", pin19: "ADC6", pin20: "AREF",
+        pin21: "GND3", pin22: "ADC7",
+        pin23: "PC0", pin24: "PC1", pin25: "PC2",
+        pin26: "PC3", pin27: "PC4_SDA", pin28: "PC5_SCL",
+        pin29: "PC6_RESET",
+        pin30: "PD0_RXD", pin31: "PD1_TXD", pin32: "PD2",
+      }}
+      pcbX="0mm"
+      pcbY="0mm"
+    />
+
+    {/* 16MHz Crystal Oscillator */}
+    <chip name="Y1" footprint="hc49s"
+      pinLabels={{ pin1: "IN", pin2: "OUT" }}
+      pcbX="0mm" pcbY="-6mm"
+    />
+
+    {/* Crystal load capacitors — 22pF each */}
+    <capacitor name="C_X1" capacitance="22pF" footprint="0805"
+      pcbX="-2mm" pcbY="-6mm" />
+    <capacitor name="C_X2" capacitance="22pF" footprint="0805"
+      pcbX="2mm" pcbY="-6mm" />
+
+    {/* VCC Decoupling — 100nF placed near VCC pin */}
+    <capacitor name="C_VCC" capacitance="100nF" footprint="0805"
+      pcbX="5mm" pcbY="1mm" />
+
+    {/* AVCC Filtering — 100nF for analog supply */}
+    <capacitor name="C_AVCC" capacitance="100nF" footprint="0805"
+      pcbX="5mm" pcbY="-1mm" />
+
+    {/* Reset Pull-up — 10kΩ pulls RESET high */}
+    <resistor name="R_RST" resistance="10kohm" footprint="0805"
+      pcbX="-5mm" pcbY="3mm" />
+
+    {/* Pin 13 LED (L) — user-controllable LED */}
+    <led name="LED_L" footprint="0805" pcbX="5mm" pcbY="3mm" />
+    <resistor name="R_L" resistance="1kohm" footprint="0805"
+      pcbX="7mm" pcbY="3mm" />
+
+    {/* === Internal Traces === */}
+
+    {/* Crystal connections */}
+    <trace path={[".Y1 > .IN", ".U1 > .XTAL1"]} />
+    <trace path={[".Y1 > .OUT", ".U1 > .XTAL2"]} />
+
+    {/* Crystal load caps: one end to crystal pin, other end to GND */}
+    <trace path={[".C_X1 > .pos", ".U1 > .XTAL1"]} />
+    <trace path={[".C_X1 > .neg", ".U1 > .GND"]} />
+    <trace path={[".C_X2 > .pos", ".U1 > .XTAL2"]} />
+    <trace path={[".C_X2 > .neg", ".U1 > .GND"]} />
+
+    {/* VCC decoupling: pos to VCC, neg to GND */}
+    <trace path={[".C_VCC > .pos", ".U1 > .VCC"]} />
+    <trace path={[".C_VCC > .neg", ".U1 > .GND"]} />
+
+    {/* AVCC decoupling: pos to AVCC, neg to GND */}
+    <trace path={[".C_AVCC > .pos", ".U1 > .AVCC"]} />
+    <trace path={[".C_AVCC > .neg", ".U1 > .GND"]} />
+
+    {/* Tie all GND pins together */}
+    <trace path={[".U1 > .GND", ".U1 > .GND2"]} />
+    <trace path={[".U1 > .GND", ".U1 > .GND3"]} />
+
+    {/* Tie all VCC pins together */}
+    <trace path={[".U1 > .VCC", ".U1 > .VCC2"]} />
+
+    {/* Reset pull-up: left to RESET, right to VCC */}
+    <trace path={[".R_RST > .left", ".U1 > .PC6_RESET"]} />
+    <trace path={[".R_RST > .right", ".U1 > .VCC"]} />
+
+    {/* Pin 13 LED: LED anode → resistor → PB5 (SCK/D13), cathode → GND */}
+    <trace path={[".LED_L > .anode", ".R_L > .left"]} />
+    <trace path={[".R_L > .right", ".U1 > .PB5_SCK"]} />
+    <trace path={[".LED_L > .cathode", ".U1 > .GND"]} />
+  </group>
+)

--- a/examples/arduino-nano/components/CH340GSerial.tsx
+++ b/examples/arduino-nano/components/CH340GSerial.tsx
@@ -1,0 +1,92 @@
+import React from "react"
+
+export const CH340GSerial = ({ name }: { name: string }) => (
+  <group name={name}>
+    {/* USB Mini-B Connector */}
+    <chip name="USB1" footprint="usb_mini_b"
+      pinLabels={{ pin1: "VBUS", pin2: "D_MINUS", pin3: "D_PLUS", pin4: "NC", pin5: "GND" }}
+      pcbX="0mm" pcbY="-18mm"
+    />
+
+    {/* CH340G USB-to-Serial Converter (SOP-16) */}
+    <chip name="U2" footprint="soic16_w3.9mm_p1.27mm"
+      pinLabels={{
+        pin1: "GND", pin2: "TXD", pin3: "RXD", pin4: "V3",
+        pin5: "UD_PLUS", pin6: "UD_MINUS", pin7: "XI", pin8: "XO",
+        pin9: "CTS", pin10: "DSR", pin11: "RI", pin12: "DCD",
+        pin13: "DTR", pin14: "RTS", pin15: "R232", pin16: "VCC",
+      }}
+      pcbX="0mm" pcbY="-12mm"
+    />
+
+    {/* 12MHz Crystal for CH340G */}
+    <chip name="Y2" footprint="hc49s"
+      pinLabels={{ pin1: "IN", pin2: "OUT" }}
+      pcbX="4mm" pcbY="-12mm"
+    />
+
+    {/* USB VBUS Decoupling — 4.7µF between VBUS and GND */}
+    <capacitor name="C_USB" capacitance="4.7uF" footprint="0805"
+      pcbX="-3mm" pcbY="-18mm" />
+
+    {/* CH340G VCC Decoupling — 100nF between VCC and GND */}
+    <capacitor name="C_CH" capacitance="100nF" footprint="0805"
+      pcbX="4mm" pcbY="-14mm" />
+
+    {/* CH340G V3 pin — internal 3.3V regulator output needs 100nF decoupling cap */}
+    <capacitor name="C_V3" capacitance="100nF" footprint="0805"
+      pcbX="-3mm" pcbY="-14mm" />
+
+    {/* TX LED */}
+    <led name="LED_TX" footprint="0805" pcbX="-4mm" pcbY="-10mm" />
+    <resistor name="R_TX" resistance="1kohm" footprint="0805"
+      pcbX="-6mm" pcbY="-10mm" />
+
+    {/* RX LED */}
+    <led name="LED_RX" footprint="0805" pcbX="-4mm" pcbY="-8mm" />
+    <resistor name="R_RX" resistance="1kohm" footprint="0805"
+      pcbX="-6mm" pcbY="-8mm" />
+
+    {/* Auto-Reset Capacitor — 100nF between DTR and MCU RESET */}
+    <capacitor name="C_RST" capacitance="100nF" footprint="0805"
+      pcbX="-5mm" pcbY="-14mm" />
+
+    {/* === Internal Traces === */}
+
+    {/* USB data lines to CH340G */}
+    <trace path={[".USB1 > .D_PLUS", ".U2 > .UD_PLUS"]} />
+    <trace path={[".USB1 > .D_MINUS", ".U2 > .UD_MINUS"]} />
+
+    {/* USB VBUS to CH340G VCC — CH340G is powered from USB */}
+    <trace path={[".USB1 > .VBUS", ".U2 > .VCC"]} />
+
+    {/* USB GND to CH340G GND */}
+    <trace path={[".USB1 > .GND", ".U2 > .GND"]} />
+
+    {/* USB VBUS decoupling cap */}
+    <trace path={[".C_USB > .pos", ".USB1 > .VBUS"]} />
+    <trace path={[".C_USB > .neg", ".USB1 > .GND"]} />
+
+    {/* CH340G VCC decoupling cap */}
+    <trace path={[".C_CH > .pos", ".U2 > .VCC"]} />
+    <trace path={[".C_CH > .neg", ".U2 > .GND"]} />
+
+    {/* CH340G V3 pin decoupling — per datasheet, V3 must have 100nF to GND */}
+    <trace path={[".C_V3 > .pos", ".U2 > .V3"]} />
+    <trace path={[".C_V3 > .neg", ".U2 > .GND"]} />
+
+    {/* 12MHz Crystal to CH340G */}
+    <trace path={[".Y2 > .IN", ".U2 > .XI"]} />
+    <trace path={[".Y2 > .OUT", ".U2 > .XO"]} />
+
+    {/* TX LED: CH340G TXD → resistor → LED anode, LED cathode → GND */}
+    <trace path={[".R_TX > .right", ".U2 > .TXD"]} />
+    <trace path={[".R_TX > .left", ".LED_TX > .anode"]} />
+    <trace path={[".LED_TX > .cathode", ".U2 > .GND"]} />
+
+    {/* RX LED: CH340G RXD → resistor → LED anode, LED cathode → GND */}
+    <trace path={[".R_RX > .right", ".U2 > .RXD"]} />
+    <trace path={[".R_RX > .left", ".LED_RX > .anode"]} />
+    <trace path={[".LED_RX > .cathode", ".U2 > .GND"]} />
+  </group>
+)

--- a/examples/arduino-nano/tests/arduino-nano.test.tsx
+++ b/examples/arduino-nano/tests/arduino-nano.test.tsx
@@ -1,0 +1,40 @@
+import React from "react"
+import { test, expect } from "bun:test"
+import { Circuit } from "@tscircuit/core"
+import { ArduinoNanoV3 } from "../ArduinoNanoV3"
+
+test("Arduino Nano V3 generates valid circuit JSON", async () => {
+  const circuit = new Circuit()
+  circuit.add(<ArduinoNanoV3 />)
+  circuit.render()
+
+  const json = circuit.getCircuitJson()
+  expect(json).toBeTruthy()
+
+  // Verify we have at least 20 source components (21 in BOM)
+  const components = json.filter((el: any) => el.type === "source_component")
+  expect(components.length).toBeGreaterThanOrEqual(20)
+})
+
+test("Arduino Nano V3 has correct board dimensions", async () => {
+  const circuit = new Circuit()
+  circuit.add(<ArduinoNanoV3 />)
+  circuit.render()
+
+  const json = circuit.getCircuitJson()
+  const board = json.find((el: any) => el.type === "pcb_board") as any
+  expect(board).toBeTruthy()
+  expect(board.width).toBe(18)
+  expect(board.height).toBe(45)
+})
+
+test("Arduino Nano V3 has traces defined", async () => {
+  const circuit = new Circuit()
+  circuit.add(<ArduinoNanoV3 />)
+  circuit.render()
+
+  const json = circuit.getCircuitJson()
+  const traces = json.filter((el: any) => el.type === "source_trace")
+  // We have 60+ traces across all modules
+  expect(traces.length).toBeGreaterThanOrEqual(30)
+})

--- a/examples/arduino-nano/tests/arduino-nano.test.tsx
+++ b/examples/arduino-nano/tests/arduino-nano.test.tsx
@@ -14,7 +14,7 @@ test("Arduino Nano V3 generates valid circuit JSON", async () => {
   // Verify we have at least 20 source components (21 in BOM)
   const components = json.filter((el: any) => el.type === "source_component")
   expect(components.length).toBeGreaterThanOrEqual(20)
-})
+}, 30000)
 
 test("Arduino Nano V3 has correct board dimensions", async () => {
   const circuit = new Circuit()
@@ -26,7 +26,7 @@ test("Arduino Nano V3 has correct board dimensions", async () => {
   expect(board).toBeTruthy()
   expect(board.width).toBe(18)
   expect(board.height).toBe(45)
-})
+}, 30000)
 
 test("Arduino Nano V3 has traces defined", async () => {
   const circuit = new Circuit()
@@ -37,4 +37,4 @@ test("Arduino Nano V3 has traces defined", async () => {
   const traces = json.filter((el: any) => el.type === "source_trace")
   // We have 60+ traces across all modules
   expect(traces.length).toBeGreaterThanOrEqual(30)
-})
+}, 30000)

--- a/examples/arduino-nano/tests/verify.tsx
+++ b/examples/arduino-nano/tests/verify.tsx
@@ -1,0 +1,41 @@
+import React from "react"
+import { Circuit } from "@tscircuit/core"
+import { ArduinoNanoV3 } from "../ArduinoNanoV3"
+
+async function runTest() {
+  console.log("🔧 Rendering Arduino Nano V3...\n")
+  const circuit = new Circuit()
+  circuit.add(<ArduinoNanoV3 />)
+  circuit.render()
+
+  const json = circuit.getCircuitJson()
+
+  // Check components
+  const components = json.filter((el: any) => el.type === "source_component")
+  console.log(`✅ Components: ${components.length} (expected ≥ 20)`)
+  if (components.length < 20) throw new Error(`Only ${components.length} components found, expected ≥ 20`)
+
+  // Check board dimensions
+  const board = json.find((el: any) => el.type === "pcb_board") as any
+  if (!board) throw new Error("No pcb_board found in circuit JSON")
+  console.log(`✅ Board: ${board.width}mm × ${board.height}mm (expected 18mm × 45mm)`)
+  if (board.width !== 18 || board.height !== 45) throw new Error("Invalid board dimensions")
+
+  // Check traces
+  const traces = json.filter((el: any) => el.type === "source_trace")
+  console.log(`✅ Traces: ${traces.length} (expected ≥ 30)`)
+  if (traces.length < 30) throw new Error(`Only ${traces.length} traces found, expected ≥ 30`)
+
+  // List component names
+  console.log("\n📋 Component List:")
+  components.forEach((c: any) => {
+    console.log(`   - ${c.name} (${c.ftype || "chip"})`)
+  })
+
+  console.log("\n🎉 All checks passed! The Arduino Nano V3 circuit is valid.")
+}
+
+runTest().catch(err => {
+  console.error("\n❌ Test failed:", err.message)
+  process.exit(1)
+})


### PR DESCRIPTION
Closes #328. This PR adds a fully modular, manufacturing-aware Arduino Nano V3.0 component layout & schematic as an example circuit design under `examples/arduino-nano/`.