### PR TITLE
fix: run global cli wrapper with node

### DIFF
--- a/cli.mjs
+++ b/cli.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env bun
+#!/usr/bin/env node
 
 import { createRequire } from "node:module";
 const require = createRequire(import.meta.url);


### PR DESCRIPTION
Fixes #2828

Summary
- Change the published `tsci`/`tscircuit` wrapper from a Bun shebang to a Node shebang.
- Keep the wrapper behavior unchanged: it still sets `global.TSCIRCUIT_VERSION` and imports `@tscircuit/cli`.
- Allows global npm installs to run `tsci` on machines without Bun installed.

Verification
- node cli.mjs --help
- bun x tsc --noEmit
- git diff --check

Note
- `bun run build` reaches the package build but fails on Windows in the existing `add-global-types-reference` script because `cat -` is not accepted by the local shell. The CLI wrapper smoke test and typecheck pass.