### PR TITLE
fix: expose this tscircuit version's bundle to tsci dev as a global fallback

### DIFF
--- a/cli.mjs
+++ b/cli.mjs
@@ -1,11 +1,30 @@
 #!/usr/bin/env bun
 
 import { createRequire } from "node:module";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 const require = createRequire(import.meta.url);
 
 // Use require to import package.json
 const packageJson = require("./package.json");
 global.TSCIRCUIT_VERSION = packageJson.version;
+
+// Expose the runframe + eval bundle shipped by this tscircuit version (the one
+// that provides the `tsci` binary) so `tsci dev` can use it when the project has
+// no local tscircuit installed. The CLI prefers a project-local tscircuit over
+// this, and an explicit RUNFRAME_STANDALONE_FILE_PATH over both.
+if (!process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH) {
+  const browserBundlePath = join(
+    dirname(fileURLToPath(import.meta.url)),
+    "dist",
+    "browser.min.js",
+  );
+  if (existsSync(browserBundlePath)) {
+    process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = browserBundlePath;
+  }
+}
 
 async function main() {
   await import("@tscircuit/cli");


### PR DESCRIPTION
cli.mjs now sets TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH to this package's dist/browser.min.js before launching the CLI, so `tsci dev` renders with the globally installed tscircuit (the one that provides the `tsci` binary) when the project has no local tscircuit. The CLI prefers a project-local tscircuit over this, and an explicit RUNFRAME_STANDALONE_FILE_PATH over both.

Requires @tscircuit/cli with the TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH reader.

related: https://github.com/tscircuit/cli/pull/3469 https://github.com/tscircuit/cli/pull/3471