### PR TITLE
feat: Arduino Nano V3.0 example circuit (#328)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Using tscircuit, you can design things like a <a target="_blank" href="https://b
 ## Example Circuits
 
 - [ESP32 Wifi Breakout Board](https://tscircuit.com/seveibar/wifi-test-board-1)
+- [Arduino Nano V3.0](https://tscircuit.com/yanyishuai/arduino-nano-v3) — ATmega328P + CH340G, 45×18 mm ([source](examples/arduino-nano))
 
 ```tsx
 const Circuit = () => (

--- a/examples/arduino-nano/README.md
+++ b/examples/arduino-nano/README.md
@@ -1,0 +1,37 @@
+# Arduino Nano V3.0 (tscircuit)
+
+Modular recreation of the [Arduino Nano](https://store-usa.arduino.cc/products/arduino-nano) using tscircuit snippets.
+
+## Board
+
+- **MCU:** ATmega328P-AU (TQFP-32)
+- **USB bridge:** CH340G (SOIC-16)
+- **Regulator:** AMS1117-5.0 (SOT-223)
+- **Form factor:** 45 mm × 18 mm (authentic Nano dimensions)
+- **Headers:** Dual 1×15 2.54 mm (D0–D13, A0–A7, power)
+
+## Modules
+
+| File | Contents |
+|------|----------|
+| `lib/PowerCircuit.tsx` | AMS1117, bulk/decoupling caps, power LED |
+| `lib/CrystalCircuit.tsx` | 16 MHz (MCU) + 12 MHz (CH340G) crystals |
+| `lib/ATmega328Circuit.tsx` | MCU, reset pull-up, auto-reset cap |
+| `lib/CH340Circuit.tsx` | USB-UART bridge |
+| `lib/UsbConnector.tsx` | Mini-USB connector |
+| `lib/LedCircuit.tsx` | TX/RX activity LEDs |
+| `lib/PinHeaders.tsx` | Nano pinout headers |
+
+## Develop
+
+```bash
+cd examples/arduino-nano
+npm install
+npx tsci dev
+```
+
+## Registry
+
+Published at: https://tscircuit.com/yanyishuai/arduino-nano-v3
+
+Closes tscircuit/tscircuit#328

--- a/examples/arduino-nano/index.tsx
+++ b/examples/arduino-nano/index.tsx
@@ -1,0 +1,23 @@
+import { ATmega328Circuit } from "./lib/ATmega328Circuit"
+import { CH340Circuit } from "./lib/CH340Circuit"
+import { CrystalCircuit } from "./lib/CrystalCircuit"
+import { LedCircuit } from "./lib/LedCircuit"
+import { PinHeaders } from "./lib/PinHeaders"
+import { PowerCircuit } from "./lib/PowerCircuit"
+import { UsbConnector } from "./lib/UsbConnector"
+
+/**
+ * Arduino Nano V3.0 (ATmega328P + CH340G) — tscircuit recreation.
+ * Reference: https://store-usa.arduino.cc/products/arduino-nano
+ */
+export default () => (
+  <board width="45mm" height="18mm" center_x={0} center_y={0}>
+    <PowerCircuit />
+    <CrystalCircuit />
+    <ATmega328Circuit />
+    <CH340Circuit />
+    <UsbConnector />
+    <LedCircuit />
+    <PinHeaders />
+  </board>
+)

--- a/examples/arduino-nano/lib/ATmega328Circuit.tsx
+++ b/examples/arduino-nano/lib/ATmega328Circuit.tsx
@@ -1,0 +1,94 @@
+export const ATmega328Circuit = () => (
+  <group name="mcu" pcbPack>
+    <chip
+      name="U1"
+      footprint="tqfp32"
+      manufacturerPartNumber="ATmega328P-AU"
+      schX={0}
+      schY={0}
+      pcbX="0mm"
+      pcbY="0mm"
+      pinLabels={{
+        pin1: "PD3",
+        pin2: "PD4",
+        pin3: "GND",
+        pin4: "VCC",
+        pin5: "GND",
+        pin6: "VCC",
+        pin7: "PB6",
+        pin8: "PB7",
+        pin9: "PD5",
+        pin10: "PD6",
+        pin11: "PD7",
+        pin12: "PB0",
+        pin13: "PB1",
+        pin14: "PB2",
+        pin15: "PB3",
+        pin16: "PB4",
+        pin17: "PB5",
+        pin18: "AVCC",
+        pin19: "ADC6",
+        pin20: "AREF",
+        pin21: "GND",
+        pin22: "ADC7",
+        pin23: "PC0",
+        pin24: "PC1",
+        pin25: "PC2",
+        pin26: "PC3",
+        pin27: "PC4",
+        pin28: "PC5",
+        pin29: "PC6",
+        pin30: "PD0",
+        pin31: "PD1",
+        pin32: "PD2",
+      }}
+      connections={{
+        VCC: ["net.V5", "C8.pin1"],
+        GND: ["net.GND", "C8.pin2", "C9.pin2"],
+        AVCC: "net.V5",
+        AREF: "net.AREF",
+        PD0: "net.UART_RX",
+        PD1: "net.UART_TX",
+        PD2: "net.INT0",
+        PC6: "net.RESET",
+      }}
+    />
+    <capacitor
+      name="C8"
+      capacitance="100nF"
+      footprint="0402"
+      schX={1}
+      schY={1}
+      pcbX="2mm"
+      pcbY="1mm"
+    />
+    <capacitor
+      name="C9"
+      capacitance="100nF"
+      footprint="0402"
+      schX={-1}
+      schY={1}
+      pcbX="-2mm"
+      pcbY="1mm"
+      connections={{ pin1: "net.AREF", pin2: "net.GND" }}
+    />
+    <resistor
+      name="R2"
+      resistance="10k"
+      footprint="0402"
+      schX={2}
+      schY={-1}
+      pcbX="3mm"
+      pcbY="-2mm"
+      connections={{ pin1: "net.V5", pin2: "net.RESET" }}
+    />
+    <capacitor
+      name="C10"
+      capacitance="100nF"
+      footprint="0402"
+      schX={3}
+      schY={-1}
+      connections={{ pin1: "U2.DTR", pin2: "net.RESET" }}
+    />
+  </group>
+)

--- a/examples/arduino-nano/lib/CH340Circuit.tsx
+++ b/examples/arduino-nano/lib/CH340Circuit.tsx
@@ -1,0 +1,49 @@
+export const CH340Circuit = () => (
+  <group name="usb_uart" pcbPack>
+    <chip
+      name="U2"
+      footprint="soic16"
+      manufacturerPartNumber="CH340G"
+      schX={4}
+      schY={0}
+      pcbX="8mm"
+      pcbY="0mm"
+      pinLabels={{
+        pin1: "GND",
+        pin2: "TXD",
+        pin3: "RXD",
+        pin4: "V3",
+        pin5: "UD+",
+        pin6: "UD-",
+        pin7: "XI",
+        pin8: "XO",
+        pin9: "CTS",
+        pin10: "DSR",
+        pin11: "RI",
+        pin12: "DCD",
+        pin13: "DTR",
+        pin14: "RTS",
+        pin15: "VCC",
+        pin16: "VCC",
+      }}
+      connections={{
+        GND: "net.GND",
+        VCC: "net.V5",
+        V3: "net.V5",
+        TXD: "net.UART_RX",
+        RXD: "net.UART_TX",
+        "UD+": "net.USB_P",
+        "UD-": "net.USB_N",
+        DTR: "net.DTR",
+      }}
+    />
+    <capacitor
+      name="C11"
+      capacitance="100nF"
+      footprint="0402"
+      schX={5}
+      schY={1}
+      connections={{ pin1: "U2.VCC", pin2: "net.GND" }}
+    />
+  </group>
+)

--- a/examples/arduino-nano/lib/CrystalCircuit.tsx
+++ b/examples/arduino-nano/lib/CrystalCircuit.tsx
@@ -1,0 +1,56 @@
+export const CrystalCircuit = () => (
+  <group name="crystals" pcbPack>
+    <crystal
+      name="Y1"
+      frequency="16MHz"
+      footprint="hc49"
+      schX={-2}
+      schY={-2}
+      pcbX="-6mm"
+      pcbY="0mm"
+      connections={{ pin1: "U1.PB6", pin2: "U1.PB7" }}
+    />
+    <capacitor
+      name="C4"
+      capacitance="22pF"
+      footprint="0402"
+      schX={-3}
+      schY={-3}
+      connections={{ pin1: "U1.PB6", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C5"
+      capacitance="22pF"
+      footprint="0402"
+      schX={-1}
+      schY={-3}
+      connections={{ pin1: "U1.PB7", pin2: "net.GND" }}
+    />
+    <crystal
+      name="Y2"
+      frequency="12MHz"
+      footprint="hc49"
+      schX={2}
+      schY={-2}
+      pcbX="4mm"
+      pcbY="0mm"
+      connections={{ pin1: "U2.XI", pin2: "U2.XO" }}
+    />
+    <capacitor
+      name="C6"
+      capacitance="22pF"
+      footprint="0402"
+      schX={1}
+      schY={-3}
+      connections={{ pin1: "U2.XI", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C7"
+      capacitance="22pF"
+      footprint="0402"
+      schX={3}
+      schY={-3}
+      connections={{ pin1: "U2.XO", pin2: "net.GND" }}
+    />
+  </group>
+)

--- a/examples/arduino-nano/lib/LedCircuit.tsx
+++ b/examples/arduino-nano/lib/LedCircuit.tsx
@@ -1,0 +1,28 @@
+export const LedCircuit = () => (
+  <group name="leds" pcbPack>
+    <resistor
+      name="R3"
+      resistance="1k"
+      footprint="0402"
+      schX={6}
+      schY={2}
+      pcbX="10mm"
+      pcbY="5mm"
+      connections={{ pin1: "U2.TXD", pin2: "L2.pin1" }}
+    />
+    <led name="L2" color="yellow" footprint="0603" schX={7} schY={2} pcbX="11mm" pcbY="5mm" />
+    <resistor
+      name="R4"
+      resistance="1k"
+      footprint="0402"
+      schX={6}
+      schY={0}
+      pcbX="10mm"
+      pcbY="3mm"
+      connections={{ pin1: "U2.RXD", pin2: "L3.pin1" }}
+    />
+    <led name="L3" color="yellow" footprint="0603" schX={7} schY={0} pcbX="11mm" pcbY="3mm" />
+    <trace from="L2.pin2" to="net.GND" />
+    <trace from="L3.pin2" to="net.GND" />
+  </group>
+)

--- a/examples/arduino-nano/lib/PinHeaders.tsx
+++ b/examples/arduino-nano/lib/PinHeaders.tsx
@@ -1,0 +1,89 @@
+/** Nano-style 2×15 2.54 mm headers (D0–D13, A0–A7, power rails). */
+export const PinHeaders = () => (
+  <group name="headers" pcbPack>
+    <pinheader
+      name="HDR1"
+      pinCount={15}
+      schX={-6}
+      schY={4}
+      pcbX="-12mm"
+      pcbY="-6mm"
+      pinLabels={Object.fromEntries(
+        [
+          "VIN",
+          "GND",
+          "RST",
+          "V5",
+          "A7",
+          "A6",
+          "A5",
+          "A4",
+          "A3",
+          "A2",
+          "A1",
+          "A0",
+          "AREF",
+          "GND",
+          "V5",
+        ].map((label, i) => [`pin${i + 1}`, label]),
+      )}
+    />
+    <pinheader
+      name="HDR2"
+      pinCount={15}
+      schX={6}
+      schY={4}
+      pcbX="12mm"
+      pcbY="-6mm"
+      pinLabels={Object.fromEntries(
+        [
+          "D13",
+          "D12",
+          "D11",
+          "D10",
+          "D9",
+          "D8",
+          "D7",
+          "D6",
+          "D5",
+          "D4",
+          "D3",
+          "D2",
+          "D1",
+          "D0",
+          "GND",
+        ].map((label, i) => [`pin${i + 1}`, label]),
+      )}
+    />
+    <trace from="HDR1.pin3" to="net.RESET" />
+    <trace from="HDR1.pin4" to="net.V5" />
+    <trace from="HDR1.pin15" to="net.V5" />
+    <trace from="HDR1.pin2" to="net.GND" />
+    <trace from="HDR1.pin14" to="net.GND" />
+    <trace from="HDR2.pin15" to="net.GND" />
+    <trace from="HDR1.pin1" to="J1.VBUS" />
+    <trace from="HDR2.pin13" to="U1.PD1" />
+    <trace from="HDR2.pin14" to="U1.PD0" />
+    <trace from="HDR2.pin12" to="U1.PD2" />
+    <trace from="HDR2.pin11" to="U1.PD3" />
+    <trace from="HDR2.pin10" to="U1.PD4" />
+    <trace from="HDR2.pin9" to="U1.PD5" />
+    <trace from="HDR2.pin8" to="U1.PD6" />
+    <trace from="HDR2.pin7" to="U1.PD7" />
+    <trace from="HDR2.pin6" to="U1.PB2" />
+    <trace from="HDR2.pin5" to="U1.PB1" />
+    <trace from="HDR2.pin4" to="U1.PB0" />
+    <trace from="HDR2.pin3" to="U1.PB3" />
+    <trace from="HDR2.pin2" to="U1.PB4" />
+    <trace from="HDR2.pin1" to="U1.PB5" />
+    <trace from="HDR1.pin13" to="net.AREF" />
+    <trace from="HDR1.pin12" to="U1.PC0" />
+    <trace from="HDR1.pin11" to="U1.PC1" />
+    <trace from="HDR1.pin10" to="U1.PC2" />
+    <trace from="HDR1.pin9" to="U1.PC3" />
+    <trace from="HDR1.pin8" to="U1.PC4" />
+    <trace from="HDR1.pin7" to="U1.PC5" />
+    <trace from="HDR1.pin6" to="U1.ADC6" />
+    <trace from="HDR1.pin5" to="U1.ADC7" />
+  </group>
+)

--- a/examples/arduino-nano/lib/PowerCircuit.tsx
+++ b/examples/arduino-nano/lib/PowerCircuit.tsx
@@ -1,0 +1,58 @@
+export const PowerCircuit = () => (
+  <group name="power" pcbPack>
+    <chip
+      name="U3"
+      footprint="sot223"
+      manufacturerPartNumber="AMS1117-5.0"
+      pinLabels={{ pin1: "GND", pin2: "VOUT", pin3: "VIN" }}
+      schX={-4}
+      schY={2}
+      pcbX="-8mm"
+      pcbY="6mm"
+    />
+    <capacitor
+      name="C1"
+      capacitance="10uF"
+      footprint="0805"
+      schX={-2}
+      schY={2}
+      pcbX="-5mm"
+      pcbY="6mm"
+      connections={{ pin1: "U3.VIN", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C2"
+      capacitance="10uF"
+      footprint="0805"
+      schX={-2}
+      schY={0}
+      pcbX="-5mm"
+      pcbY="4mm"
+      connections={{ pin1: "U3.VOUT", pin2: "net.GND" }}
+    />
+    <capacitor
+      name="C3"
+      capacitance="100nF"
+      footprint="0402"
+      schX={0}
+      schY={0}
+      pcbX="-3mm"
+      pcbY="4mm"
+      connections={{ pin1: "U3.VOUT", pin2: "net.GND" }}
+    />
+    <resistor
+      name="R1"
+      resistance="1k"
+      footprint="0402"
+      schX={2}
+      schY={2}
+      pcbX="0mm"
+      pcbY="7mm"
+      connections={{ pin1: "net.V5", pin2: "L1.pin1" }}
+    />
+    <led name="L1" color="green" footprint="0603" schX={3} schY={2} pcbX="2mm" pcbY="7mm" />
+    <trace from="U3.VOUT" to="net.V5" />
+    <trace from="U3.GND" to="net.GND" />
+    <trace from="L1.pin2" to="net.GND" />
+  </group>
+)

--- a/examples/arduino-nano/lib/UsbConnector.tsx
+++ b/examples/arduino-nano/lib/UsbConnector.tsx
@@ -1,0 +1,25 @@
+export const UsbConnector = () => (
+  <group name="usb" pcbPack>
+    <chip
+      name="J1"
+      footprint="usb_mini_b"
+      schX={8}
+      schY={0}
+      pcbX="14mm"
+      pcbY="0mm"
+      pinLabels={{
+        pin1: "VBUS",
+        pin2: "D-",
+        pin3: "D+",
+        pin4: "ID",
+        pin5: "GND",
+      }}
+      connections={{
+        VBUS: "U3.VIN",
+        "D+": "net.USB_P",
+        "D-": "net.USB_N",
+        GND: "net.GND",
+      }}
+    />
+  </group>
+)

--- a/examples/arduino-nano/package.json
+++ b/examples/arduino-nano/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@tsci/yanyishuai.arduino-nano-v3",
+  "version": "0.0.1",
+  "main": "index.tsx",
+  "keywords": ["tscircuit", "arduino", "nano"],
+  "scripts": {
+    "dev": "tsci dev",
+    "build": "tsci build",
+    "format": "biome format --write ."
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.9",
+    "tscircuit": "^0.0.614"
+  }
+}


### PR DESCRIPTION
## Summary

Modular Arduino Nano V3.0 recreation for tscircuit (#328, $100).

## Deliverables

- `examples/arduino-nano/` — full board design (ATmega328P-AU, CH340G, AMS1117, crystals, LEDs, Mini-USB, dual headers)
- README link: https://tscircuit.com/yanyishuai/arduino-nano-v3

## Board

| Spec | Value |
|------|-------|
| MCU | ATmega328P-AU (TQFP-32) |
| USB | CH340G + Mini-USB |
| Regulator | AMS1117-5.0 |
| Size | 45 mm × 18 mm |

## Modules

- `lib/PowerCircuit.tsx` — 5 V regulation + power LED
- `lib/CrystalCircuit.tsx` — 16 MHz + 12 MHz crystals
- `lib/ATmega328Circuit.tsx` — MCU + reset network
- `lib/CH340Circuit.tsx` — USB-UART bridge
- `lib/UsbConnector.tsx` — Mini-USB
- `lib/LedCircuit.tsx` — TX/RX LEDs
- `lib/PinHeaders.tsx` — Nano pinout (D0–D13, A0–A7)

## Test plan

1. `cd examples/arduino-nano && npm install && npx tsci dev`
2. Verify schematic + PCB render in browser
3. Cross-check pin mapping against official Nano pinout

## Wallet

`Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`

/claim #328

Closes #328
