### PR TITLE
Link the Arduino Nano bounty example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Using tscircuit, you can design things like a <a target="_blank" href="https://b
 ## Example Circuits
 
 - [ESP32 Wifi Breakout Board](https://tscircuit.com/seveibar/wifi-test-board-1)
+- [Arduino Nano V3.0](https://tscircuit.com/Abse2001/Arduino-Nano)
 
 ```tsx
 const Circuit = () => (


### PR DESCRIPTION
Adds the Arduino Nano example circuit link to the README for the bounty issue.

/claim #328

Validation:
- README link points to the example circuit for Arduino Nano.