### PR TITLE
Remove manifold-3d dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -59,7 +59,6 @@
         "kicad-component-converter": "^0.1.40",
         "kicad-to-circuit-json": "^0.0.97",
         "kicadts": "^0.0.47",
-        "manifold-3d": "^3.4.1",
         "minicssgrid": "^0.0.9",
         "performance-now": "^2.1.0",
         "poppygl": "^0.0.25",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
     "kicad-component-converter": "^0.1.40",
     "kicad-to-circuit-json": "^0.0.97",
     "kicadts": "^0.0.47",
-    "manifold-3d": "^3.4.1",
     "minicssgrid": "^0.0.9",
     "performance-now": "^2.1.0",
     "poppygl": "^0.0.25",

--- a/tests/manifold-dependency.test.ts
+++ b/tests/manifold-dependency.test.ts
@@ -1,0 +1,72 @@
+import { expect, test } from "bun:test"
+import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import packageJson from "../package.json"
+
+test("published package does not depend on manifold-3d", async () => {
+  const manifest = packageJson as unknown as {
+    dependencies?: Record<string, string>
+    optionalDependencies?: Record<string, string>
+    peerDependencies?: Record<string, string>
+    bundleDependencies?: string[]
+    bundledDependencies?: string[]
+  }
+
+  expect(manifest.dependencies?.["manifold-3d"]).toBeUndefined()
+  expect(manifest.optionalDependencies?.["manifold-3d"]).toBeUndefined()
+  expect(manifest.peerDependencies?.["manifold-3d"]).toBeUndefined()
+  expect(manifest.bundleDependencies ?? []).not.toContain("manifold-3d")
+  expect(manifest.bundledDependencies ?? []).not.toContain("manifold-3d")
+
+  const auditDir = await mkdtemp(join(tmpdir(), "tscircuit-dependency-audit-"))
+  const packDir = join(auditDir, "pack")
+  const installDir = join(auditDir, "install")
+
+  try {
+    await mkdir(packDir)
+    await mkdir(installDir)
+
+    const npmEnv = {
+      ...process.env,
+      npm_config_cache: join(auditDir, "npm-cache"),
+    }
+    const pack = Bun.spawnSync(["npm", "pack", "--pack-destination", packDir], {
+      cwd: new URL("..", import.meta.url).pathname,
+      env: npmEnv,
+    })
+    expect(pack.exitCode, pack.stderr.toString()).toBe(0)
+
+    const [tarballName] = await readdir(packDir)
+    expect(tarballName).toEndWith(".tgz")
+
+    await Bun.write(
+      join(installDir, "package.json"),
+      JSON.stringify({ private: true }),
+    )
+    const install = Bun.spawnSync(
+      [
+        "npm",
+        "install",
+        "--ignore-scripts",
+        "--no-audit",
+        "--no-fund",
+        join(packDir, tarballName),
+      ],
+      { cwd: installDir, env: npmEnv },
+    )
+    expect(install.exitCode, install.stderr.toString()).toBe(0)
+
+    const lockfile = await Bun.file(
+      join(installDir, "package-lock.json"),
+    ).text()
+    expect(lockfile).not.toContain('"node_modules/manifold-3d"')
+    expect(
+      await Bun.file(
+        join(installDir, "node_modules/manifold-3d/package.json"),
+      ).exists(),
+    ).toBe(false)
+  } finally {
+    await rm(auditDir, { recursive: true, force: true })
+  }
+}, 60_000)


### PR DESCRIPTION
## Summary
- remove the stale direct `manifold-3d` dependency from the published `tscircuit` package
- remove it from the root lockfile dependency list
- add a release regression test covering direct, optional, peer, bundled, and transitive production dependencies

## Root cause

The release sync in `scripts/copy-core-versions.ts` updates versions shared with `@tscircuit/core`, but it does not remove dependencies that core no longer declares. As a result, `tscircuit@0.0.2056` still directly installed `manifold-3d@3.5.1` even though the new core/copper-pour path uses `@tscircuit/manifold-2d`.

The regression test packs the local package, installs the resulting tarball in a clean temporary project, then verifies the generated npm lockfile and installed tree contain no `manifold-3d`. This exercises the actual published production dependency graph rather than the development workspace's peer-dependency lock artifacts.

## Verification
- `bun run build`
- `bunx tsc --noEmit`
- `bun test` — 3 passed
- clean packed-tarball install contains no `manifold-3d` manifest, lock entry, or installed package
- `bun install --frozen-lockfile --ignore-scripts`
- Biome check and `git diff --check`

## Separate runtime finding

The copied runframe browser standalone still contains a runtime CDN reference to `manifold-3d@3.2.1` in its CAD viewer. That is not an npm dependency and is outside this focused package-tree fix; it should be migrated upstream in runframe separately.