### PR TITLE
fix: restore automated dependency updates

### DIFF
--- a/scripts/copy-core-versions.ts
+++ b/scripts/copy-core-versions.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 
 const DO_NOT_SYNC_PACKAGE = [
   "@biomejs/biome",
+  "@tsci/tscircuit.ti",
   "@tscircuit/import-snippet",
   "@tscircuit/layout",
   "@tscircuit/log-soup",


### PR DESCRIPTION
## Summary

- exclude the core-only `@tsci/tscircuit.ti` development fixture from dependency synchronization
- restore the automated package-update workflows

## Root cause

`@tscircuit/core@0.0.1512` added `@tsci/tscircuit.ti` as a GitHub-pinned dev dependency. `copy-core-versions.ts` treats unclassified core dependencies as missing from the root `tscircuit` package and aborted before the update workflow could create its pull request.

The fixture is only used to develop and test core, so it should follow the existing `DO_NOT_SYNC_PACKAGE` pattern rather than be shipped by the umbrella package.

## Validation

- reproduced the failure from Actions run `30154597597`, job `89670476549`
- ran `bun update --latest @tscircuit/core @tscircuit/cli @tscircuit/eval @tscircuit/runframe`
- ran `bun run copy-core-versions` successfully with `@tscircuit/core@0.0.1512`
- ran `git diff --check`
