### PR TITLE
chore: remove unused dist/webworker.min.js build step

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,11 @@
     "globals.d.ts"
   ],
   "scripts": {
-    "build": "tsup-node && bun run copy-runframe-standalone && bun run copy-eval-webworker && cp types/static-assets.d.ts dist/static-assets.d.ts && bun run add-global-types-reference",
+    "build": "tsup-node && bun run copy-runframe-standalone && cp types/static-assets.d.ts dist/static-assets.d.ts && bun run add-global-types-reference",
     "add-global-types-reference": "echo '/// <reference path=\"../globals.d.ts\" />' | cat - dist/index.d.ts > dist/index.d.ts.tmp && mv dist/index.d.ts.tmp dist/index.d.ts",
     "test": "bun test",
     "upgrade-deps": "bun update --latest @tscircuit/core @tscircuit/cli @tscircuit/eval && bun run copy-core-versions && bun install --ignore-scripts",
     "copy-runframe-standalone": "bun run scripts/copy-runframe-standalone.ts",
-    "copy-eval-webworker": "bun run scripts/copy-eval-webworker.ts",
     "copy-core-versions": "bun run scripts/copy-core-versions.ts && bun install --ignore-scripts"
   },
   "exports": {

--- a/scripts/copy-eval-webworker.ts
+++ b/scripts/copy-eval-webworker.ts
@@ -1,9 +1,0 @@
-import { mkdir, copyFile } from 'fs/promises';
-import { join } from 'node:path';
-
-const src = join(import.meta.dirname, '../node_modules/@tscircuit/eval/dist/webworker/entrypoint.js');
-const destDir = join(import.meta.dirname, '../dist');
-const dest = join(destDir, 'webworker.min.js');
-
-await mkdir(destDir, { recursive: true });
-await copyFile(src, dest);


### PR DESCRIPTION
## What

Removes `scripts/copy-eval-webworker.ts` and the `copy-eval-webworker` step from the `build` script. This stops publishing `dist/webworker.min.js` in the npm package.

## Why

`copy-eval-webworker.ts` was introduced in #732 to copy the eval webworker entrypoint into `dist/webworker.min.js` so that a **future** build's `copy-runframe-standalone.ts` could fetch it from `cdnjs.cloudflare.com/ajax/libs/tscircuit/<version>/webworker.min.js` (see the old `getWorkerBlobUrl` implementation).

#741 ("Remove CDN Fetch for webworker.min.js") replaced that CDN fetch with a direct read from `node_modules/@tscircuit/eval/dist/webworker/entrypoint.js`, and the worker is now embedded as a base64 blob URL directly inside `dist/browser.min.js` at build time. After that change, nothing reads `dist/webworker.min.js` anymore — I checked `@tscircuit/cli`, `@tscircuit/runframe`, and `@tscircuit/eval`; the only remaining fallback path fetches the webworker from `@tscircuit/eval`'s own CDN copy (jscdn.tscircuit.com / jsdelivr / unpkg), never from `tscircuit`'s own `dist/webworker.min.js`.

So `dist/webworker.min.js` (~10MB) has been dead weight shipped in every published `tscircuit` version since #741 merged, with no code path consuming it.

## Verification

- `bun run build` still succeeds and produces a working `dist/browser.min.js` that has the worker blob URL embedded (no leftover `<--INJECT_TSCIRCUIT_EVAL_WEB_WORKER_BLOB_URL-->` placeholder), confirming this change doesn't affect the embedding logic in `copy-runframe-standalone.ts`.
- `bun test` passes (3/3), including `tests/manifold-dependency.test.ts` which does a real `npm pack`/`npm install` audit of the published tarball.
- `bun pm pack` output shows the packed tarball no longer contains `dist/webworker.min.js`; unpacked size drops from ~35MB to ~24.9MB with everything else unchanged.