### PR TITLE
fix: fail build when runframe worker blob injection misses

### DIFF
--- a/scripts/copy-runframe-standalone.ts
+++ b/scripts/copy-runframe-standalone.ts
@@ -1,22 +1,66 @@
-import { mkdir, writeFile, readFile } from 'fs/promises';
-import { join } from 'node:path';
+import { access, mkdir, writeFile, readFile } from "fs/promises"
+import { join } from "node:path"
 
-const src = join(import.meta.dirname, '../node_modules/@tscircuit/runframe/dist/standalone.min.js');
-const destDir = join(import.meta.dirname, '../dist');
-const dest = join(destDir, 'browser.min.js');
+const PLACEHOLDER = '"<--INJECT_TSCIRCUIT_EVAL_WEB_WORKER_BLOB_URL-->"'
+const PLACEHOLDER_RE = /"<--INJECT_TSCIRCUIT_EVAL_WEB_WORKER_BLOB_URL-->"/g
 
-const content = await readFile(src, 'utf-8');
+const src = join(
+  import.meta.dirname,
+  "../node_modules/@tscircuit/runframe/dist/standalone.min.js",
+)
+const workerPath = join(
+  import.meta.dirname,
+  "../node_modules/@tscircuit/eval/dist/webworker/entrypoint.js",
+)
+const destDir = join(import.meta.dirname, "../dist")
+const dest = join(destDir, "browser.min.js")
 
-const workerPath = join(import.meta.dirname, '../node_modules/@tscircuit/eval/dist/webworker/entrypoint.js');
-const workerJs = await readFile(workerPath, 'utf-8');
-const base64Worker = Buffer.from(workerJs).toString('base64');
-const workerBlobUrl = `URL.createObjectURL(new Blob([atob(\"${base64Worker}\")], { type: 'application/javascript' }))`;
+async function assertReadable(path: string, label: string) {
+  try {
+    await access(path)
+  } catch {
+    throw new Error(
+      `Missing ${label} at ${path}. Run bun install before building.`,
+    )
+  }
+}
+
+await assertReadable(src, "@tscircuit/runframe standalone bundle")
+await assertReadable(workerPath, "@tscircuit/eval webworker entrypoint")
+
+const content = await readFile(src, "utf-8")
+const placeholderMatches = content.match(PLACEHOLDER_RE)?.length ?? 0
+
+if (placeholderMatches === 0) {
+  throw new Error(
+    `Runframe standalone bundle is missing the expected worker placeholder ${PLACEHOLDER}. ` +
+      `Refusing to publish a broken browser.min.js. Check @tscircuit/runframe compatibility.`,
+  )
+}
+
+const workerJs = await readFile(workerPath, "utf-8")
+const base64Worker = Buffer.from(workerJs).toString("base64")
+const workerBlobUrl = `URL.createObjectURL(new Blob([atob("${base64Worker}")], { type: 'application/javascript' }))`
 
 // Replace the quoted placeholder (including the surrounding quotes) with the JS expression
-const modifiedContent = content.replace(
-  /"<--INJECT_TSCIRCUIT_EVAL_WEB_WORKER_BLOB_URL-->"/g,
-  workerBlobUrl
-);
+const modifiedContent = content.replace(PLACEHOLDER_RE, workerBlobUrl)
 
-await mkdir(destDir, { recursive: true });
-await writeFile(dest, modifiedContent);
+const leftover = modifiedContent.match(PLACEHOLDER_RE)?.length ?? 0
+if (leftover > 0) {
+  throw new Error(
+    `Failed to inject eval webworker blob URL: ${leftover} placeholder(s) remain after replacement.`,
+  )
+}
+
+if (!modifiedContent.includes("URL.createObjectURL(new Blob([atob(")) {
+  throw new Error(
+    "Worker blob URL injection produced a bundle without the expected createObjectURL(atob(...)) expression.",
+  )
+}
+
+await mkdir(destDir, { recursive: true })
+await writeFile(dest, modifiedContent)
+
+console.log(
+  `Injected eval webworker into browser.min.js (${placeholderMatches} placeholder(s) replaced)`,
+)

--- a/tests/copy-runframe-standalone.test.ts
+++ b/tests/copy-runframe-standalone.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test"
+import { access, readFile } from "node:fs/promises"
+import { join } from "node:path"
+import { $ } from "bun"
+
+const root = join(import.meta.dirname, "..")
+const browserBundle = join(root, "dist", "browser.min.js")
+const placeholder = "<--INJECT_TSCIRCUIT_EVAL_WEB_WORKER_BLOB_URL-->"
+
+test("copy-runframe-standalone injects worker blob and leaves no placeholder", async () => {
+  const result = await $`bun run scripts/copy-runframe-standalone.ts`.cwd(root)
+  expect(result.exitCode).toBe(0)
+
+  await access(browserBundle)
+  const content = await readFile(browserBundle, "utf-8")
+
+  expect(content.includes(placeholder)).toBe(false)
+  const injectedBlobMarker = "URL.createObjectURL(new Blob([atob("
+  expect(content.includes(injectedBlobMarker)).toBe(true)
+}, 60_000)


### PR DESCRIPTION
## Summary
- Harden `scripts/copy-runframe-standalone.ts` so the build **fails** if the `@tscircuit/runframe` standalone bundle is missing the eval webworker placeholder, if injection leaves leftovers, or if required source files are absent.
- Previously the replace was best-effort: a runframe placeholder rename/compat break would still write `dist/browser.min.js` and publish a silently broken browser bundle.
- Add `tests/copy-runframe-standalone.test.ts` that re-runs the copy script and asserts the placeholder is gone and the blob URL expression is present.

## Test plan
- [x] `bun run build` succeeds and logs `Injected eval webworker into browser.min.js (1 placeholder(s) replaced)`
- [x] `bun test tests/copy-runframe-standalone.test.ts tests/smoke1.test.tsx tests/smoke2.test.tsx` passes
- [x] Confirmed missing-placeholder path would throw (stripped placeholder → 0 matches)