### PR TITLE
fix: rewrite copy-core-versions with JSON-safe updates

### DIFF
--- a/scripts/copy-core-versions.ts
+++ b/scripts/copy-core-versions.ts
@@ -1,8 +1,7 @@
 import corePackageJson from "@tscircuit/core/package.json"
-import currentPackageJson from "../package.json"
 import { join } from "node:path"
 
-const DO_NOT_SYNC_PACKAGE = [
+export const DO_NOT_SYNC_PACKAGE = [
   "@biomejs/biome",
   "@tsci/tscircuit.ti",
   "@tscircuit/import-snippet",
@@ -27,60 +26,81 @@ const DO_NOT_SYNC_PACKAGE = [
   "concurrently",
   "nanoid",
   "eecircuit-engine",
-  "stack-svgs"
+  "stack-svgs",
 ]
 
-const coreDeps: any = {
-  ...corePackageJson.devDependencies,
-  ...corePackageJson.dependencies,
+export type DepMap = Record<string, string>
+
+export type PackageJsonLike = {
+  dependencies?: DepMap
+  devDependencies?: DepMap
 }
 
-const currentDeps: any = {
-  ...currentPackageJson.devDependencies,
-  ...currentPackageJson.dependencies,
-}
-const depsToUpdate: any = {}
-
-let modifiedDeps = false
-// Update dependencies to match core
-for (const [packageName, currentVersion] of Object.entries(currentDeps)) {
-  if (packageName in coreDeps && coreDeps[packageName] !== currentVersion) {
-    console.log(
-      `Updating ${packageName} from ${currentVersion} to ${coreDeps[packageName]}`,
-    )
-    depsToUpdate[packageName] = coreDeps[packageName as keyof typeof coreDeps]
-    modifiedDeps = true
-  }
-}
-
-// Check for missing core dependencies
-const missingDeps: string[] = []
-for (const packageName of Object.keys(coreDeps)) {
-  if (
-    DO_NOT_SYNC_PACKAGE.some((dnsp) =>
-      dnsp.includes("*")
-        ? packageName.startsWith(dnsp.replace("*", ""))
-        : packageName === dnsp,
-    )
-  ) {
-    continue
-  }
-  if (!(packageName in currentDeps)) {
-    missingDeps.push(packageName)
-  }
-}
-
-if (missingDeps.length > 0) {
-  throw new Error(
-    `Missing core dependencies in package.json: ${missingDeps.join(", ")}. ` +
-      `\n\nAdd them to package.json or add to DO_NOT_SYNC_PACKAGE list.`,
+export function shouldSkipPackage(packageName: string) {
+  return DO_NOT_SYNC_PACKAGE.some((dnsp) =>
+    dnsp.endsWith("*")
+      ? packageName.startsWith(dnsp.slice(0, -1))
+      : packageName === dnsp,
   )
 }
 
-if (modifiedDeps) {
-  // Use regex to replace the dependencies in the package.json
-  const packageJsonPath = join(import.meta.dirname, "../package.json")
-  let packageJson = await Bun.file(packageJsonPath).text()
+export function getDepMaps(pkg: PackageJsonLike): DepMap {
+  return {
+    ...(pkg.devDependencies ?? {}),
+    ...(pkg.dependencies ?? {}),
+  }
+}
+
+export function applyCoreVersionUpdates(
+  currentPackageJson: PackageJsonLike,
+  corePackageJson: PackageJsonLike,
+) {
+  const coreDeps = getDepMaps(corePackageJson)
+  const currentDeps = getDepMaps(currentPackageJson)
+
+  const updates: Array<{
+    section: "dependencies" | "devDependencies"
+    packageName: string
+    from: string
+    to: string
+  }> = []
+
+  for (const section of ["dependencies", "devDependencies"] as const) {
+    const sectionDeps = currentPackageJson[section]
+    if (!sectionDeps) continue
+
+    for (const [packageName, currentVersion] of Object.entries(sectionDeps)) {
+      const coreVersion = coreDeps[packageName]
+      if (coreVersion && coreVersion !== currentVersion) {
+        updates.push({
+          section,
+          packageName,
+          from: currentVersion,
+          to: coreVersion,
+        })
+        sectionDeps[packageName] = coreVersion
+      }
+    }
+  }
+
+  const missingDeps: string[] = []
+  for (const packageName of Object.keys(coreDeps)) {
+    if (shouldSkipPackage(packageName)) continue
+    if (!(packageName in currentDeps)) {
+      missingDeps.push(packageName)
+    }
+  }
+
+  return { updates, missingDeps, currentPackageJson }
+}
+
+/** Legacy regex rewriter — kept for tests to prove silent misses. */
+export function legacyRegexUpdatePackageJson(
+  packageJsonText: string,
+  depsToUpdate: DepMap,
+  currentDeps: DepMap,
+) {
+  let packageJson = packageJsonText
   for (const [packageName, version] of Object.entries(depsToUpdate)) {
     const pattern = `"${packageName}":\\s*"${currentDeps[packageName].replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"(,)?`
     packageJson = packageJson.replace(
@@ -88,5 +108,41 @@ if (modifiedDeps) {
       `"${packageName}": "${version}"$1`,
     )
   }
-  await Bun.write(packageJsonPath, packageJson)
+  return packageJson
+}
+
+if (import.meta.main) {
+  const packageJsonPath = join(import.meta.dirname, "../package.json")
+  const packageJsonText = await Bun.file(packageJsonPath).text()
+  const currentPackageJson = JSON.parse(packageJsonText) as PackageJsonLike
+
+  const { updates, missingDeps } = applyCoreVersionUpdates(
+    currentPackageJson,
+    corePackageJson as PackageJsonLike,
+  )
+
+  if (missingDeps.length > 0) {
+    throw new Error(
+      `Missing core dependencies in package.json: ${missingDeps.join(", ")}. ` +
+        `\n\nAdd them to package.json or add to DO_NOT_SYNC_PACKAGE list.`,
+    )
+  }
+
+  if (updates.length > 0) {
+    for (const update of updates) {
+      console.log(
+        `Updating ${update.packageName} (${update.section}) from ${update.from} to ${update.to}`,
+      )
+    }
+
+    // Write via JSON so version updates cannot silently no-op when formatting
+    // differs from the previous regex-based rewriter.
+    await Bun.write(
+      packageJsonPath,
+      `${JSON.stringify(currentPackageJson, null, 2)}\n`,
+    )
+    console.log(`Wrote ${updates.length} dependency update(s) to package.json`)
+  } else {
+    console.log("All synced dependencies already match @tscircuit/core")
+  }
 }

--- a/tests/copy-core-versions.test.ts
+++ b/tests/copy-core-versions.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "bun:test"
+import {
+  applyCoreVersionUpdates,
+  legacyRegexUpdatePackageJson,
+} from "../scripts/copy-core-versions"
+
+test("JSON updater rewrites awkwardly spaced dependency entries", () => {
+  const packageJsonText = `{
+  "dependencies": {
+    "zod" : "^3.0.0",
+    "@tscircuit/math-utils": "^0.0.1"
+  },
+  "devDependencies": {}
+}
+`
+
+  const currentPackageJson = JSON.parse(packageJsonText) as {
+    dependencies: Record<string, string>
+    devDependencies: Record<string, string>
+  }
+
+  const corePackageJson = {
+    dependencies: {
+      zod: "^3.25.67",
+      "@tscircuit/math-utils": "^0.0.36",
+    },
+    devDependencies: {},
+  }
+
+  const { updates, missingDeps, currentPackageJson: updated } =
+    applyCoreVersionUpdates(currentPackageJson, corePackageJson)
+
+  expect(missingDeps).toEqual([])
+  expect(updates).toHaveLength(2)
+  expect(updated.dependencies?.zod).toBe("^3.25.67")
+  expect(updated.dependencies?.["@tscircuit/math-utils"]).toBe("^0.0.36")
+
+  // Prove the previous regex rewriter silently missed spaced keys.
+  const legacy = legacyRegexUpdatePackageJson(
+    packageJsonText,
+    {
+      zod: "^3.25.67",
+      "@tscircuit/math-utils": "^0.0.36",
+    },
+    {
+      zod: "^3.0.0",
+      "@tscircuit/math-utils": "^0.0.1",
+    },
+  )
+  expect(legacy.includes('"zod" : "^3.0.0"')).toBe(true)
+  expect(legacy.includes('"@tscircuit/math-utils": "^0.0.36"')).toBe(true)
+})
+
+test("copy-core-versions script exits cleanly against this package.json", async () => {
+  const result = Bun.spawnSync(["bun", "run", "scripts/copy-core-versions.ts"], {
+    cwd: new URL("..", import.meta.url).pathname,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  expect(result.exitCode, result.stderr.toString()).toBe(0)
+})


### PR DESCRIPTION
## Summary
- Replace the regex-based `package.json` rewriter in `scripts/copy-core-versions.ts` with a parse → mutate → `JSON.stringify` path so dependency sync cannot silently no-op.
- The previous pattern required `"name": "version"` with no space before `:`; entries like `"zod" : "^3.0.0"` were left unchanged while the script still exited 0.
- Export helpers for testability and add regression tests that prove awkward spacing is updated and that the legacy regex path still misses it.

## Test plan
- [x] `bun test tests/copy-core-versions.test.ts` passes (2/2)
- [x] `bun run scripts/copy-core-versions.ts` exits 0 against current package.json (`All synced dependencies already match @tscircuit/core`)
- [x] Confirmed legacy regex leaves `"zod" : "^3.0.0"` untouched while JSON updater rewrites it