### PR TITLE
fix: harden global types reference step and CLI startup errors

### DIFF
--- a/cli.mjs
+++ b/cli.mjs
@@ -23,11 +23,22 @@ if (!process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH) {
   );
   if (existsSync(browserBundlePath)) {
     process.env.TSCIRCUIT_GLOBAL_STANDALONE_FILE_PATH = browserBundlePath;
+  } else {
+    console.warn(
+      `[tscircuit] Warning: bundled browser runtime missing at ${browserBundlePath}. ` +
+        `Run \`bun run build\` before using \`tsci dev\` from this install.`,
+    );
   }
 }
 
 async function main() {
-  await import("@tscircuit/cli");
+  try {
+    await import("@tscircuit/cli");
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    console.error(`[tscircuit] Failed to start CLI:\n${message}`);
+    process.exitCode = 1;
+  }
 }
 
 main();

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "globals.d.ts"
   ],
   "scripts": {
-    "build": "tsup-node && bun run copy-runframe-standalone && bun run copy-eval-webworker && cp types/static-assets.d.ts dist/static-assets.d.ts && bun run add-global-types-reference",
-    "add-global-types-reference": "echo '/// <reference path=\"../globals.d.ts\" />' | cat - dist/index.d.ts > dist/index.d.ts.tmp && mv dist/index.d.ts.tmp dist/index.d.ts",
+    "build": "tsup-node && bun run copy-runframe-standalone && bun run copy-eval-webworker && bun run add-global-types-reference",
+    "add-global-types-reference": "bun run scripts/add-global-types-reference.ts",
     "test": "bun test",
     "upgrade-deps": "bun update --latest @tscircuit/core @tscircuit/cli @tscircuit/eval @tscircuit/runframe && bun run copy-core-versions && bun install --ignore-scripts",
     "copy-runframe-standalone": "bun run scripts/copy-runframe-standalone.ts",

--- a/scripts/add-global-types-reference.ts
+++ b/scripts/add-global-types-reference.ts
@@ -1,0 +1,47 @@
+import { access, copyFile, mkdir, readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+const REFERENCE_LINE = '/// <reference path="../globals.d.ts" />'
+const root = join(import.meta.dirname, "..")
+const distDir = join(root, "dist")
+const indexDtsPath = join(distDir, "index.d.ts")
+const globalsPath = join(root, "globals.d.ts")
+const staticAssetsDest = join(distDir, "static-assets.d.ts")
+
+async function assertExists(path: string, label: string) {
+  try {
+    await access(path)
+  } catch {
+    throw new Error(`Missing ${label} at ${path}`)
+  }
+}
+
+await assertExists(indexDtsPath, "generated dist/index.d.ts")
+await assertExists(globalsPath, "globals.d.ts")
+
+const original = await readFile(indexDtsPath, "utf-8")
+const trimmed = original.replace(/^\uFEFF/, "")
+
+let next = trimmed
+if (!trimmed.startsWith(REFERENCE_LINE)) {
+  // Drop any prior accidental duplicate reference lines, then prepend once.
+  const withoutRefs = trimmed
+    .split("\n")
+    .filter((line) => line.trim() !== REFERENCE_LINE)
+    .join("\n")
+  next = `${REFERENCE_LINE}\n${withoutRefs}`
+}
+
+await mkdir(distDir, { recursive: true })
+await writeFile(indexDtsPath, next)
+
+// Keep published static asset module typings identical to globals.d.ts so the
+// two copies cannot drift across releases.
+await copyFile(globalsPath, staticAssetsDest)
+
+console.log(
+  trimmed.startsWith(REFERENCE_LINE)
+    ? "dist/index.d.ts already references globals.d.ts"
+    : "Prepended globals.d.ts reference to dist/index.d.ts",
+)
+console.log("Synced dist/static-assets.d.ts from globals.d.ts")

--- a/tests/add-global-types-reference.test.ts
+++ b/tests/add-global-types-reference.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "bun:test"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { $ } from "bun"
+
+const root = join(import.meta.dirname, "..")
+const referenceLine = '/// <reference path="../globals.d.ts" />'
+
+test("add-global-types-reference prepends once and syncs static-assets.d.ts", async () => {
+  const distDir = join(root, "dist")
+  await mkdir(distDir, { recursive: true })
+  await writeFile(join(distDir, "index.d.ts"), "export * from '@tscircuit/core'\n")
+
+  const first = await $`bun run scripts/add-global-types-reference.ts`.cwd(root)
+  expect(first.exitCode).toBe(0)
+
+  const afterFirst = await readFile(join(distDir, "index.d.ts"), "utf-8")
+  expect(afterFirst.startsWith(`${referenceLine}\n`)).toBe(true)
+  expect(afterFirst.split(referenceLine).length - 1).toBe(1)
+
+  const second = await $`bun run scripts/add-global-types-reference.ts`.cwd(root)
+  expect(second.exitCode).toBe(0)
+  const afterSecond = await readFile(join(distDir, "index.d.ts"), "utf-8")
+  expect(afterSecond.split(referenceLine).length - 1).toBe(1)
+
+  const globals = await readFile(join(root, "globals.d.ts"), "utf-8")
+  const staticAssets = await readFile(join(distDir, "static-assets.d.ts"), "utf-8")
+  expect(staticAssets).toBe(globals)
+}, 30_000)
+
+test("cli wrapper reports a clear error when @tscircuit/cli cannot load", async () => {
+  const tmp = join(root, ".tmp-cli-error-test")
+  await rm(tmp, { recursive: true, force: true })
+  await mkdir(tmp, { recursive: true })
+
+  await writeFile(
+    join(tmp, "cli.mjs"),
+    `#!/usr/bin/env bun
+try {
+  await import("./missing-cli-module.js")
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  console.error("[tscircuit] Failed to start CLI:\\n" + message)
+  process.exitCode = 1
+}
+`,
+  )
+
+  const result = Bun.spawnSync(["bun", "cli.mjs"], {
+    cwd: tmp,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  expect(result.exitCode).toBe(1)
+  expect(result.stderr.toString()).toContain("[tscircuit] Failed to start CLI:")
+
+  await rm(tmp, { recursive: true, force: true })
+})


### PR DESCRIPTION
## Summary
- Replace the shell `echo | cat | mv` `add-global-types-reference` step with `scripts/add-global-types-reference.ts`, which is idempotent (won’t double-prepend) and fails clearly if `dist/index.d.ts` / `globals.d.ts` are missing.
- Sync `dist/static-assets.d.ts` from `globals.d.ts` during that step so the two declaration copies cannot drift.
- Harden `cli.mjs` to catch CLI import/startup failures with a clear `[tscircuit] Failed to start CLI` message and `exitCode = 1`, and warn when the bundled `dist/browser.min.js` is missing (shebang intentionally unchanged).

## Test plan
- [x] `bun test tests/add-global-types-reference.test.ts tests/smoke1.test.tsx tests/smoke2.test.tsx` passes (4/4)
- [x] `bun run build` prepends the globals reference once and syncs `dist/static-assets.d.ts`
- [x] `cmp globals.d.ts dist/static-assets.d.ts` identical
- [x] `bun cli.mjs --help` still works