### PR TITLE
Update graphics-debug to its Sharp-free release

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "debug": "^4.3.6",
     "flatbush": "^4.5.0",
     "format-si-unit": "^0.0.12",
-    "graphics-debug": "^0.0.95",
+    "graphics-debug": "^0.0.99",
     "jscad-planner": "^0.0.13",
     "kicad-component-converter": "^0.1.40",
     "kicad-to-circuit-json": "^0.0.117",


### PR DESCRIPTION
Updates graphics-debug to 0.0.99 so downstream installs no longer resolve its old looks-same@9/Sharp peer. This is part of removing install-time libvips downloads from Core CI. The umbrella package builds successfully.