### PR TITLE
fix: ignore bundled winding solver in dependency sync

### DIFF
--- a/scripts/copy-core-versions.ts
+++ b/scripts/copy-core-versions.ts
@@ -12,6 +12,7 @@ const DO_NOT_SYNC_PACKAGE = [
   "@tscircuit/schematic-autolayout",
   "@tscircuit/jlcpcb-manufacturing-specs",
   "@tscircuit/breakout-point-solver",
+  "@tscircuit/winding-breakout-point-solver",
   "@tscircuit/eecircuit-engine",
   "@types/*",
   "tsup",


### PR DESCRIPTION
## Summary
- treat the winding breakout point solver as an internal dependency bundled by Core
- prevent the dependency-sync script from requiring an unsupported GitHub dependency in the published tscircuit package
- unblock automated Core/Eval dependency updates

## Verification
- bun run upgrade-deps
- bun run build
- smoke tests pass locally; the packaging audit's fresh npm install exceeds its local 60-second timeout