### PR TITLE
fix: ignore bundled winding breakout solver during sync

### DIFF
--- a/scripts/copy-core-versions.ts
+++ b/scripts/copy-core-versions.ts
@@ -12,6 +12,7 @@ const DO_NOT_SYNC_PACKAGE = [
   "@tscircuit/schematic-autolayout",
   "@tscircuit/jlcpcb-manufacturing-specs",
   "@tscircuit/breakout-point-solver",
+  "@tscircuit/winding-breakout-point-solver",
   "@tscircuit/eecircuit-engine",
   "@types/*",
   "tsup",


### PR DESCRIPTION
## Summary

- exclude `@tscircuit/winding-breakout-point-solver` from the core dependency sync check
- match the existing treatment of `@tscircuit/breakout-point-solver` from #3305
- avoid adding a redundant direct dependency: Core declares the solver as a dev dependency and bundles it through `noExternal`
- unblock the `Update @tscircuit Package` workflow failure from run 32668243817

This is the lean alternative to #4608, which adds the bundled solver and its transitive dependencies directly to the `tscircuit` package.

## Verification

- reproduced the workflow update against `@tscircuit/core@0.0.1740`; `bun run scripts/copy-core-versions.ts` completes without missing dependencies
- `bun run build`
- `git diff --check`

## Local test note

`bun test` passed the smoke test, then the existing published-package check in `tests/manifold-dependency.test.ts` timed out after 60 seconds while spawning its package-install subprocess. That network-bound timeout is unrelated to this sync-list-only change.
