### PR TITLE
ci: reject pkg.pr.new lockfile entries

### DIFF
--- a/.github/workflows/check-package-dependency-sources.yml
+++ b/.github/workflows/check-package-dependency-sources.yml
@@ -39,3 +39,12 @@ jobs:
             echo "$forbidden_dependencies"
             exit 1
           fi
+
+      - name: Reject pkg.pr.new lockfile entries
+        shell: bash
+        run: |
+          if grep -nFq "pkg.pr.new" bun.lock; then
+            echo "::error file=bun.lock::bun.lock contains forbidden pkg.pr.new dependency sources:"
+            grep -nF "pkg.pr.new" bun.lock
+            exit 1
+          fi


### PR DESCRIPTION
## Summary\n\n- Keep the structured package.json dependency-source validation unchanged.\n- Reject literal pkg.pr.new entries anywhere in committed bun.lock.\n- Emit a file-annotated error and matching lockfile line numbers for quick diagnosis.\n\nThis prevents stale transitive or peer-resolution snapshots like the one removed in #4752 from surviving a manifest-only check.\n\n## Validation\n\n- Current package.json structured check passes.\n- Current bun.lock has zero pkg.pr.new matches and passes.\n- A streamed synthetic pkg.pr.new lock entry is rejected with exit code 1 and the expected bun.lock error.\n- git diff --check\n