### PR TITLE
fix: update copper-pour-solver for oval plated-hole clearance

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
         "@tscircuit/checks": "^0.0.178",
         "@tscircuit/circuit-json-util": "^0.0.106",
         "@tscircuit/cli": "^0.1.2021",
-        "@tscircuit/copper-pour-solver": "^0.0.51",
+        "@tscircuit/copper-pour-solver": "^0.0.52",
         "@tscircuit/core": "^0.0.1837",
         "@tscircuit/create-fdm-enclosure": "0.0.4",
         "@tscircuit/eval": "^0.0.1343",
@@ -293,7 +293,7 @@
 
     "@tscircuit/cli": ["@tscircuit/cli@0.1.2021", "", { "peerDependencies": { "circuit-json": "^0.0.464", "tscircuit": "*" }, "bin": { "tscircuit-cli": "cli/entrypoint.js" } }, "sha512-KXSi/HrCIa69ZnvlACOYjzwdvh5r4c5kVlIA8IYR6fGQbYv71QfBLfIF/fqmGlQ7bSuaEwSzrkhf4iL0sUREow=="],
 
-    "@tscircuit/copper-pour-solver": ["@tscircuit/copper-pour-solver@0.0.51", "", { "dependencies": { "@tscircuit/manifold-2d": "^0.0.6" }, "peerDependencies": { "typescript": "^5" } }, "sha512-/e5OHr9yA/bAl5QQGA8pkL3dTVw/ksmrID3XzVkh4ezBi9A0/y1va5KcXWbxEWNp1dcPltItJMyq2rErVHMNkw=="],
+    "@tscircuit/copper-pour-solver": ["@tscircuit/copper-pour-solver@0.0.52", "", { "dependencies": { "@tscircuit/manifold-2d": "^0.0.6" }, "peerDependencies": { "typescript": "^5" } }, "sha512-LMeWsgZTmDLdZB7XrGxmZmkYXwzF3R0qFcNXK8q6NBlJTGu8yxTZfhApiZUphPFodqa0v/UyILLlLLX4cN1sIg=="],
 
     "@tscircuit/core": ["@tscircuit/core@0.0.1837", "", { "dependencies": { "@flatten-js/core": "^1.6.2", "@lume/kiwi": "^0.4.3", "calculate-cell-boundaries": "^0.0.19", "calculate-packing": "^0.0.89", "css-select": "5.1.0", "format-si-unit": "^0.0.12", "nanoid": "^5.0.7", "performance-now": "^2.1.0", "react-reconciler": "^0.32.0", "svg-path-commander": "^2.1.11", "transformation-matrix": "^2.16.1", "zod": "^3.25.67" }, "peerDependencies": { "@tscircuit/capacity-autorouter": "*", "@tscircuit/checks": "*", "@tscircuit/circuit-json-util": "*", "@tscircuit/create-fdm-enclosure": "*", "@tscircuit/footprinter": "*", "@tscircuit/infgrid-ijump-astar": "*", "@tscircuit/matchpack": "*", "@tscircuit/math-utils": "*", "@tscircuit/props": "*", "@tscircuit/schematic-match-adapt": "*", "bpc-graph": "*", "circuit-json": "*", "circuit-json-to-bpc": "*", "circuit-json-to-connectivity-map": "*", "circuit-json-to-spice": "*", "schematic-symbols": "*", "spicets": "*", "typescript": "^5.0.0" } }, "sha512-9M3DT94/HNuNDNFfQyfU8RtLouLngIvVi5v/5RBoh22NBGnhzCcw/P8wwk8SULvG/S48lO2tFjak7YibFrHeCg=="],
 
@@ -836,6 +836,8 @@
     "react-reconciler/scheduler": ["scheduler@0.26.0", "", {}, "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA=="],
 
     "tscircuit/@tscircuit/capacity-autorouter": ["@tscircuit/capacity-autorouter@0.0.851", "", { "dependencies": { "fast-json-stable-stringify": "^2.1.0", "object-hash": "^3.0.0", "stack-svgs": "^0.0.1" } }, "sha512-/QaYCfJcX8ss54nznXsDKjVmkuMTS2aH8iPVD3rxyrrab/01VdyF0mQ53EQSg0iLnxPdt2KF1MSdBlnBzRq+zg=="],
+
+    "tscircuit/@tscircuit/copper-pour-solver": ["@tscircuit/copper-pour-solver@0.0.51", "", { "dependencies": { "@tscircuit/manifold-2d": "^0.0.6" }, "peerDependencies": { "typescript": "^5" } }, "sha512-/e5OHr9yA/bAl5QQGA8pkL3dTVw/ksmrID3XzVkh4ezBi9A0/y1va5KcXWbxEWNp1dcPltItJMyq2rErVHMNkw=="],
 
     "tscircuit/@tscircuit/core": ["@tscircuit/core@0.0.1802", "", { "dependencies": { "@flatten-js/core": "^1.6.2", "@lume/kiwi": "^0.4.3", "calculate-cell-boundaries": "^0.0.19", "calculate-packing": "^0.0.86", "css-select": "5.1.0", "format-si-unit": "^0.0.12", "nanoid": "^5.0.7", "performance-now": "^2.1.0", "react-reconciler": "^0.32.0", "svg-path-commander": "^2.1.11", "transformation-matrix": "^2.16.1", "zod": "^3.25.67" }, "peerDependencies": { "@tscircuit/capacity-autorouter": "*", "@tscircuit/checks": "*", "@tscircuit/circuit-json-util": "*", "@tscircuit/create-fdm-enclosure": "*", "@tscircuit/footprinter": "*", "@tscircuit/infgrid-ijump-astar": "*", "@tscircuit/matchpack": "*", "@tscircuit/math-utils": "*", "@tscircuit/props": "*", "@tscircuit/schematic-match-adapt": "*", "bpc-graph": "*", "circuit-json": "*", "circuit-json-to-bpc": "*", "circuit-json-to-connectivity-map": "*", "circuit-json-to-spice": "*", "schematic-symbols": "*", "spicets": "*", "typescript": "^5.0.0" } }, "sha512-yTmnf9KmMqkFg+jFkmho2RvXZQFA87b76amQDcHzfHuRpITeGEWZTthyjDmfzba2XIoQbBSp2RGw9BmaM6n2WA=="],
 

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@tscircuit/checks": "^0.0.178",
     "@tscircuit/circuit-json-util": "^0.0.106",
     "@tscircuit/cli": "^0.1.2021",
-    "@tscircuit/copper-pour-solver": "^0.0.51",
+    "@tscircuit/copper-pour-solver": "^0.0.52",
     "@tscircuit/core": "^0.0.1837",
     "@tscircuit/create-fdm-enclosure": "0.0.4",
     "@tscircuit/eval": "^0.0.1343",


### PR DESCRIPTION
## Why

Copper pours need to respect the clearance around oval plated holes, such as elongated through-hole battery contacts. The previous solver omitted `pcb_plated_hole` elements with `shape: "oval"` when converting Circuit JSON into solver obstacles. As a result, a different-net pour could extend into the pad's required clearance. Same-net oval plated holes also lacked thermal-relief support.

This affected the oval battery pads on the ATTiny85 Arcade Keychain. Updating the shared dependency brings the fix to designs using the `tscircuit` package without requiring board-specific keepouts.

## What changed

Update `@tscircuit/copper-pour-solver` from `^0.0.51` to `^0.0.52` and refresh `bun.lock`. The release includes https://github.com/tscircuit/copper-pour-solver/pull/86, which preserves oval pad dimensions and rotation, offsets their elliptical geometry by the configured clearance, and supports thermal-relief spokes.

## Validation

- Both local smoke tests passed.
- `git diff --check` passed.
- The full `bun test` run did not pass: the `published package does not depend on manifold-3d` audit timed out after 60 seconds during its clean npm installation.
- The solver change was separately validated with all 51 solver tests, TypeScript checks, and its production build.
