### PR TITLE
fix: skip via stitch solver dependency sync

### DIFF
--- a/scripts/copy-core-versions.ts
+++ b/scripts/copy-core-versions.ts
@@ -14,6 +14,7 @@ const DO_NOT_SYNC_PACKAGE = [
   "@tscircuit/bga-fanout-solver",
   "@tscircuit/breakout-point-solver",
   "@tscircuit/implicit-copper-pour-solver",
+  "@tscircuit/via-stitch-solver",
   "@tscircuit/winding-breakout-point-solver",
   "@tscircuit/eecircuit-engine",
   "@types/*",


### PR DESCRIPTION
## Summary

- Treat `@tscircuit/via-stitch-solver` like the other core-only solver development dependencies.
- Prevent `copy-core-versions` from rejecting automated `@tscircuit/core` updates.

Fixes the failure in https://github.com/tscircuit/tscircuit/actions/runs/34164090442/job/101871591008.

## Testing

- `bun update --latest @tscircuit/core @tscircuit/cli @tscircuit/eval @tscircuit/runframe`
- `bun run copy-core-versions`