### PR TITLE
fix: export Fragment from tscircuit

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 export * from "@tscircuit/core"
 export * from "@tscircuit/eval"
+export { Fragment } from "react"
 export type { AnyCircuitElement, CircuitJson } from "circuit-json"
 export type { ChipProps, PinLabelsProp, CommonLayoutProps } from "@tscircuit/props"
 export { kicadFootprintStrings } from "@tscircuit/props"


### PR DESCRIPTION
Re-export React's `Fragment` from the package entry point so users can write `import { Fragment } from "tscircuit"` without importing it separately from React. The export is included in both the JavaScript build and TypeScript declarations.

Validation: `bun run build` and `bun test` pass (3 tests). Also verified that the built package's `Fragment` export is identical to React's `Fragment` and can create a React element.
