### PR TITLE
test(circuits): add I2C bus pull-up resistor calculation tests

### DIFF
--- a/tests/i2c-pullup-calc-specs.test.ts
+++ b/tests/i2c-pullup-calc-specs.test.ts
@@ -1,0 +1,12 @@
+import test from "ava"
+
+test("tscircuit: should calculate optimal I2C pull-up resistor range based on bus capacitance", (t) => {
+  const vdd = 3.3
+  const cBusPf = 100 // 100 pF bus capacitance
+  const trMaxNs = 300 // max rise time 300ns for Fast Mode 400kHz
+  
+  // R_max = t_r / (0.8473 * C_b)
+  const rMaxOhms = (trMaxNs * 1e-9) / (0.8473 * (cBusPf * 1e-12))
+  t.true(rMaxOhms > 3000 && rMaxOhms < 4000)
+  t.pass("I2C pull-up resistor maximum resistance constraint verified")
+})


### PR DESCRIPTION
### Summary
- Adds circuit calculation unit tests determining I2C bus pull-up resistor values based on bus capacitance and signal rise-time constraints.
- Prevents signal degradation on 400kHz Fast-mode buses.